### PR TITLE
Fixes indexing bug

### DIFF
--- a/chi_square_tests.py
+++ b/chi_square_tests.py
@@ -144,7 +144,7 @@ def chi_square_independence(s):
     # caclulate the test statistic, T
     T = 0
     for i in range(q):
-        T += float((bins[q][1] - bins[q][2])**2)/bins[q][2]
+        T += float((bins[i][1] - bins[i][2])**2)/bins[i][2]
 
     # return statistic with q-1 df (since our indices start at 0, df is q)
     return T, q


### PR DESCRIPTION
From #4...

In `chi_square_tests.py` on line 147. The line

    T += float((bins[q][1] - bins[q][2])**2)/bins[q][2]

should be 

    T += float((bins[i][1] - bins[i][2])**2)/bins[i][2]

as `q` is the size of the bin.  