### PR TITLE
Fixes padding bug

### DIFF
--- a/permutation_tests.py
+++ b/permutation_tests.py
@@ -66,11 +66,18 @@ def conversion1(s):
 # conversion II
 # partitions the sequences into 8-bit non-overlapping blocks, and calculates the integer value of each block. 
 def conversion2(s):
+
     sp = str(s)[1:-1]
     sp = sp.replace(', ','')
-    padded = sp + '0' * (8 - len(s) % 8)
-    sp_bytes = [int(padded[i:i+8], 2) for i in range(0,len(padded),8)]
     
+    if len(s) % 8 == 0:
+        padding = 0
+    else:
+        padding = 8 - len(s) % 8
+
+    padded = sp + '0' * padding
+    sp_bytes = [int(padded[i:i+8], 2) for i in range(0,len(padded),8)]
+
     return sp_bytes
 
 

--- a/permutation_tests.py
+++ b/permutation_tests.py
@@ -66,16 +66,9 @@ def conversion1(s):
 # conversion II
 # partitions the sequences into 8-bit non-overlapping blocks, and calculates the integer value of each block. 
 def conversion2(s):
-
     sp = str(s)[1:-1]
     sp = sp.replace(', ','')
-    
-    if len(s) % 8 == 0:
-        padding = 0
-    else:
-        padding = 8 - len(s) % 8
-
-    padded = sp + '0' * padding
+    padded = sp + '0' * ((len(s) % 8 == 0) ? 0 : (8 - len(s) % 8))
     sp_bytes = [int(padded[i:i+8], 2) for i in range(0,len(padded),8)]
 
     return sp_bytes

--- a/permutation_tests.py
+++ b/permutation_tests.py
@@ -68,7 +68,13 @@ def conversion1(s):
 def conversion2(s):
     sp = str(s)[1:-1]
     sp = sp.replace(', ','')
-    padded = sp + '0' * ((len(s) % 8 == 0) ? 0 : (8 - len(s) % 8))
+    
+    if len(s) % 8 == 0:
+        padding = 0
+    else:
+        padding = 8 - len(s) % 8
+
+    padded = sp + '0' * padding
     sp_bytes = [int(padded[i:i+8], 2) for i in range(0,len(padded),8)]
 
     return sp_bytes


### PR DESCRIPTION
From #6...

In the `conversion2` method inside `permutation_tests.py`, there is a corner case that is mishandled. When the length of the dataset is a multiple of 8, an extra block of 0's is added to the end of the data instead of just having no padding at all.

Specifically, 

    8 - len(s) % 8

becomes 8 when `len(s)` is a multiple of 8 (as `len(s) % 8 = 0`). All other cases operate as expected.