### PR TITLE
don't panic about small dataset;  print informative message instead

### DIFF
--- a/chi_square_tests.py
+++ b/chi_square_tests.py
@@ -306,7 +306,7 @@ def goodness_of_fit(subsets):
 # Return the chi-square cutoff (or critical value) for the given degrees
 # of freedom for p = 0.001.
 def chi_square_cutoff(df):
-    assert df > 0
+    if df <= 0: return 0
 
     if df < 101:
         return critical_value[df]

--- a/chi_square_tests.py
+++ b/chi_square_tests.py
@@ -31,6 +31,8 @@ def pass_chi_square_tests(dataset, verbose=False):
     cutoff = chi_square_cutoff(df)
     if verbose:
         print("\nChi square independence\n\tscore = %g, degrees of freedom = %d, cut-off = %g" % (score, df, cutoff))
+        if df == 0:
+            print("\tnot enough data;  try using >= 300000 samples")
 
     if score < cutoff:
         if verbose:


### PR DESCRIPTION
This addresses issue #12.

``assert`` should be used for conditions that should never happen.

df==0 can definitely happen, so handle it gracefully and print an informative message
