### PR TITLE
Made all the binary search code more conservative; the code can now d…

### DIFF
--- a/SP90Bv2_predictors.py
+++ b/SP90Bv2_predictors.py
@@ -9,12 +9,10 @@
 # March 3, 2106
 
 
-
 from collections import Counter, defaultdict
 import math
 import sys
-from decimal import * #needed for qn
-getcontext().prec = 10
+from is_close import isclose
 
 
 #############################
@@ -38,23 +36,33 @@ def find_root(p,r):
     # Feller states that in practice, second element is usually sufficient.
     # Iterate 10 times and take result.
 
-    p = Decimal(str(p))
-    q = 1-p
+    p = p
+    q = 1.0-p
 
-    s = Decimal(1) #last value of sequence. This is s_0.
+    s = 1 #last value of sequence. This is s_0.
     for i in range(10):
-            s = 1+q*(p**r)*(s**(r+1))
+            s = 1.0+q*((p*s)**r)*s
     return s
-    
-def calc_qn(p,r,n):
-    p = Decimal(str(p))
-    q = 1-p
-    x = Decimal(str(find_root(p,r)))
-    
-    qn = (1-p*x)/Decimal((r+1-r*x)*q)
-    qn = qn/(x**(n+1))
 
-    return qn
+def iterativePowMul(m, b, e):
+    r = m
+    curPow = b
+    bitmask = 0x01
+
+    while e != 0:
+        if e & bitmask:
+            r = r * curPow 
+            e = e & (~bitmask)
+        curPow = curPow * curPow
+        bitmask = bitmask << 1
+
+    return r
+ 
+def calc_qn(p,r,n):
+    q = 1-p
+    x = find_root(p,r)
+    
+    return iterativePowMul((1.0-p*x)/((r+1.0-r*x)*q), 1/x, n+1)
 
 def findMaxRun(correct):
     #find the longest run
@@ -77,32 +85,59 @@ def findMaxRun(correct):
 def calcRun(correct, verbose=False):
     N = len(correct)
     alpha = 0.99
+    tolerance = 1e-09
+
+    #our target is close to 1.0, so the system DBL_EPSILON is fine
+    absEpsilon = 4.0 * sys.float_info.epsilon
     
     #find the longest run        
     r = findMaxRun(correct)
-    alpha = Decimal(str(alpha))
-    
+
+    ldomain = 0.0
+    hdomain = 1.0
+
+    lbound = ldomain
+    lvalue = float("inf")
+    hbound = hdomain
+    hvalue = float("-inf")
+
     # do a binary search for p
-    p = Decimal(str(0.5))
-    adj = Decimal(str(0.5))
+    center = (lbound + hbound) / 2
+    assert (center > ldomain) and (center < hdomain)
 
-    #find probability there is no run of length r+1
-    qn = calc_qn(p,r+1,N)
-     
+    centerVal = calc_qn(center,r+1,N)
 
-    for i in range(30): 
-            adj /= 2
-            if qn > alpha:
-                    p += adj
-            else:
-                    p -= adj
-                    
-            qn = calc_qn(p,r+1,N)
-            if abs(qn-alpha) <= 0.0001: break
-   
-    return p
-        
-    
+    for rounds in range(1076):
+        if isclose(alpha, centerVal, tolerance, absEpsilon):
+            return True, center, r+1
+
+        if lbound >= hbound:
+            print ("Bounds have converged after %d rounds and target was not found" % rounds)
+            return False, -1.0, r+1
+
+        if alpha < centerVal:
+            lbound = center
+            lvalue = centerVal
+        else:
+            hbound = center
+            hvalue = centerVal
+
+        if (alpha > lvalue) or (alpha < hvalue):
+            print ("Target is not within the search interval after %d rounds" % rounds)
+            return False, -1.0, r+1
+
+        center = (lbound + hbound) / 2.0
+
+        if (center <= ldomain) or (center >= hdomain):
+            print ("The next center is outside of the proscribed domain after %d rounds" % rounds)
+            return False, -1.0, r+1
+
+        centerVal = calc_qn(center,r+1,N)
+
+    if isclose(alpha, centerVal, tolerance, absEpsilon):
+        return True, p, r+1
+    else:
+        return False, -1.0, r+1
 
 ################################
 # MultiMCW Prediction Estimate #
@@ -141,7 +176,7 @@ def MultiMCW(S, verbose=False):
         if verbose and i%10000 ==0:
             sys.stdout.write("\rComputing MultiMCW Prediction Estimate: %d percent complete" % (float(i)/L*100))
             sys.stdout.flush()
-        
+
         #step 3a
         for j in [0,1,2,3]: #adjusted for index starting at 0
             if i>w[j]+1:
@@ -180,7 +215,9 @@ def MultiMCW(S, verbose=False):
     Pavg = calcPavg(C, N)
 
     #step 6
-    Prun = calcRun(correct)
+    foundIt, Prun, myr = calcRun(correct, verbose)
+    if not foundIt:
+        print ("Couldn't locate target")
 
     #step 7
     minH = -math.log(max(Pavg, Prun),2)
@@ -188,6 +225,7 @@ def MultiMCW(S, verbose=False):
     if verbose:
         print("\n\tPglobal: %f" % Pavg)
         print("\tPlocal: %f"% Prun)
+
 
     return [max(Pavg, Prun), minH]
 
@@ -243,7 +281,9 @@ def Lag(S, verbose=False):
     Pavg = calcPavg(C, N)
 
     #step 6
-    Prun = calcRun(correct)\
+    foundIt, Prun, myr = calcRun(correct, verbose)
+    if not foundIt:
+        print ("Couldn't locate target")
 
     #step 7
     minH = -math.log(max(Pavg, Prun),2)
@@ -331,7 +371,9 @@ def MultiMMC(S, verbose=False):
     Pavg = calcPavg(C, N)
 
     #step 7
-    Prun = calcRun(correct)
+    foundIt, Prun, myr = calcRun(correct, verbose)
+    if not foundIt:
+        print ("Couldn't locate target")
 
     #step 8
     minH = -math.log(max(Pavg, Prun),2)
@@ -399,7 +441,9 @@ def LZ78Y(S, verbose=False):
     Pavg = calcPavg(C, N)
 
     #step 5
-    Prun = calcRun(correct)
+    foundIt, Prun, myr = calcRun(correct, verbose)
+    if not foundIt:
+        print ("Couldn't locate target")
 
     #step 6
     minH = -math.log(max(Pavg, Prun),2)

--- a/is_close.py
+++ b/is_close.py
@@ -1,0 +1,101 @@
+"""
+
+Test implementation for an isclose() function, for possible inclusion in
+the Python standard library -- PEP0485
+
+This version has multiple methods in it for experimentation and testing.
+
+The "final" version can be found in isclose.py
+
+This implementation is the result of much discussion on the python-ideas list
+in January, 2015:
+
+   https://mail.python.org/pipermail/python-ideas/2015-January/030947.html
+
+   https://mail.python.org/pipermail/python-ideas/2015-January/031124.html
+
+   https://mail.python.org/pipermail/python-ideas/2015-January/031313.html
+
+Copyright: Christopher H. Barker
+License: Apache License 2.0 http://opensource.org/licenses/apache2.0.php
+
+"""
+import cmath
+
+
+def isclose(a,
+            b,
+            rel_tol=1e-9,
+            abs_tol=0.0,
+            method='weak'):
+    """
+    returns True if a is close in value to b. False otherwise
+
+    :param a: one of the values to be tested
+
+    :param b: the other value to be tested
+
+    :param rel_tol=1e-8: The relative tolerance -- the amount of error
+                         allowed, relative to the magnitude of the input
+                         values.
+
+    :param abs_tol=0.0: The minimum absolute tolerance level -- useful for
+                        comparisons to zero.
+
+    :param method: The method to use. options are:
+                  "asymmetric" : the b value is used for scaling the tolerance
+                  "strong" : The tolerance is scaled by the smaller of
+                             the two values
+                  "weak" : The tolerance is scaled by the larger of
+                           the two values
+                  "average" : The tolerance is scaled by the average of
+                              the two values.
+
+    NOTES:
+
+    -inf, inf and NaN behave similar to the IEEE 754 standard. That
+    -is, NaN is not close to anything, even itself. inf and -inf are
+    -only close to themselves.
+
+    Complex values are compared based on their absolute value.
+
+    The function can be used with Decimal types, if the tolerance(s) are
+    specified as Decimals::
+
+      isclose(a, b, rel_tol=Decimal('1e-9'))
+
+    See PEP-0485 for a detailed description
+
+    """
+    if method not in ("asymmetric", "strong", "weak", "average"):
+        raise ValueError('method must be one of: "asymmetric",'
+                         ' "strong", "weak", "average"')
+
+    if rel_tol < 0.0 or abs_tol < 0.0:
+        raise ValueError('error tolerances must be non-negative')
+
+    if a == b:  # short-circuit exact equality
+        return True
+    # use cmath so it will work with complex or float
+    if cmath.isinf(a) or cmath.isinf(b):
+        # This includes the case of two infinities of opposite sign, or
+        # one infinity and one finite number. Two infinities of opposite sign
+        # would otherwise have an infinite relative tolerance.
+        return False
+    diff = abs(b - a)
+    if method == "asymmetric":
+        return (diff <= abs(rel_tol * b)) or (diff <= abs_tol)
+    elif method == "strong":
+        return (((diff <= abs(rel_tol * b)) and
+                 (diff <= abs(rel_tol * a))) or
+                (diff <= abs_tol))
+    elif method == "weak":
+        return (((diff <= abs(rel_tol * b)) or
+                 (diff <= abs(rel_tol * a))) or
+                (diff <= abs_tol))
+    elif method == "average":
+        return ((diff <= abs(rel_tol * (a + b) / 2) or
+                (diff <= abs_tol)))
+    else:
+        raise ValueError('method must be one of:'
+                         ' "asymmetric", "strong", "weak", "average"')

--- a/maurer.py
+++ b/maurer.py
@@ -14,6 +14,11 @@
 from math import sqrt
 from math import log
 from math import floor
+
+import numpy as np
+import sys
+
+from is_close import isclose
 #from multiprocessing import Pool
 
 
@@ -49,26 +54,64 @@ def EppM(p, n, v):
 
 # Binary search algorithm to find value of p s.t. the expected value
 # of the Maurer Universal Statistic equals mu_bar within tolerance
-def solve_for_p(mu_bar, n, v, tolerance=0.00001):
-    minp = 1.0/float(n) 
-    p = (1-minp)/2.0+minp
-    adj = (1-minp)
+#presumes a decreasing function
+def solve_for_p(mu_bar, n, v, tolerance=1e-09):
+    assert n > 0
 
-    Ep_maxvalid = EppM(1.0/float(n), n, v)
-    if mu_bar > Ep_maxvalid:
+    #This is a hackish way of checking to see if the difference is within approximately 4 ULPs
+    absEpsilon = 4.0 * max((np.nextafter(mu_bar, mu_bar+1.0) - mu_bar), (mu_bar - np.nextafter(mu_bar, mu_bar-1.0)))
+    #If we don't have numpy, then this will work for most of the ranges we're concerned with
+    #absEpsilon = sys.float_info.epsilon
+
+    if mu_bar > EppM(1.0/float(n), n, v):
         return False, 0.0
 
-    Ep = EppM(p, n, v)
-    while abs(mu_bar - Ep) > tolerance:
-        adj /= 2.0
-        if mu_bar > Ep:
-            p -= adj
+    ldomain = 1.0/float(n)
+    hdomain = 1.0
+
+    lbound = ldomain
+    lvalue = float("inf")
+    hbound = hdomain
+    hvalue = float("-inf")
+
+    #Note that the bounds are in the interval [0, 1], so underflows
+    #are an issue, but overflows are not
+    center = (lbound + hbound) / 2
+    assert (center > ldomain) and (center < hdomain)
+
+    centerVal = EppM(center, n, v)
+
+    for rounds in range(1076):
+        if isclose(mu_bar, centerVal, tolerance, absEpsilon):
+            return True, center;
+
+        if lbound >= hbound:
+            print ("Bounds have converged after %d rounds and target was not found" % rounds)
+            return False, 0.0
+
+        if mu_bar < centerVal:
+            lbound = center
+            lvalue = centerVal
         else:
-            p += adj
-        Ep = EppM(p, n, v)
+            hbound = center
+            hvalue = centerVal
 
-    return True, p
+        if (mu_bar > lvalue) or (mu_bar < hvalue):
+            print ("Target is not within the search interval after %d rounds" % rounds)
+            return False, 0.0
 
+        center = (lbound + hbound) / 2.0
+
+        if (center <= ldomain) or (center >= hdomain):
+            print ("The next center is outside of the proscribed domain after %d rounds" % rounds)
+            return False, 0.0
+        
+        centerVal = EppM(center, n, v)
+
+    if isclose(mu_bar, centerVal, tolerance, absEpsilon):
+        return True, p
+    else:
+        return False, 0.0
 
 # Maurer Universal Statistic compression test
 
@@ -120,7 +163,8 @@ def maurer_universal_statistic(dataset, k):
     sigma = c*sigma
 
     # 5. Compute the lower-bound of the 99% confidence interval for the mean 
-    #    based on a normal distribution
+    #    based on a normal distribution (student-T distribution is the nominal
+    #    distribution, but the sample size is expected to be large.)
     mu_bar = mu - (2.576*sigma)/sqrt(v)
     #print("\tmu=%g, sigma=%g, mu_bar=%g\n" % (mu, sigma, mu_bar))
     


### PR DESCRIPTION
Made all the binary search code more conservative; the code can now detect a variety of common errors. Refined the tests for closeness within the binary searches, so that they now use isclose(). Removed use of Decimal in the predictor code, and use a binary exponentiation routine rather than the ** operator to avoid aborting on encountering underflow errors (these errors are expected, and treating underflows as identically 0.0 is appropriate in this context). Resolves usnistgov/SP800-90B_EntropyAssessment#23. Resolves usnistgov/SP800-90B_EntropyAssessment#19. Resolves usnistgov/SP800-90B_EntropyAssessment#17.