### PR TITLE
Modified to use packed data, enhance verbose output, increase efficie…

### DIFF
--- a/iid_main.py
+++ b/iid_main.py
@@ -35,10 +35,13 @@ if __name__ == '__main__':
     datafile = args.datafile
     bits_per_symbol = int(args.bits_per_symbol)
     verbose = bool(args.verbose)
+    start_position = int (args.start_position)
+    read_amount = int (args.read_amount)
 
     with open(datafile, 'rb') as file:
         # Read in raw bytes and convert to list of output symbols
-        bytes_in = bytearray(file.read())
+        bytes_in = bytearray(file.read(start_position))
+        bytes_in = bytearray(file.read(read_amount))
         dataset = to_dataset(bytes_in, bits_per_symbol)
         k = len(set(dataset))
         if verbose:

--- a/iid_main.py
+++ b/iid_main.py
@@ -18,7 +18,7 @@ import time
 import sys
 
 
-from util90b import get_parser, to_dataset
+from util90b import get_parser, to_dataset_packed, to_dataset_unpacked
 from permutation_tests import permutation_test
 from chi_square_tests import pass_chi_square_tests
 from mostCommonValue import most_common
@@ -38,12 +38,16 @@ if __name__ == '__main__':
     verbose = bool(args.verbose)
     start_position = int (args.start_position)
     read_amount = int (args.read_amount)
+    packed = bool (args.packed)
 
     with open(datafile, 'rb') as file:
         # Read in raw bytes and convert to list of output symbols
         file.seek(start_position, os.SEEK_SET)
         bytes_in = bytearray(file.read(read_amount))
-        dataset = to_dataset(bytes_in, bits_per_symbol)
+        if packed:
+          dataset = to_dataset_packed (bytes_in, bits_per_symbol)
+        else:
+          dataset = to_dataset_unpacked (bytes_in, bits_per_symbol)
         k = len(set(dataset))
         if verbose:
             # print file and dataset details

--- a/iid_main.py
+++ b/iid_main.py
@@ -13,6 +13,7 @@
 #
 # February 2016
 
+import os
 import time
 import sys
 
@@ -40,7 +41,7 @@ if __name__ == '__main__':
 
     with open(datafile, 'rb') as file:
         # Read in raw bytes and convert to list of output symbols
-        bytes_in = bytearray(file.read(start_position))
+        file.seek(start_position, os.SEEK_SET)
         bytes_in = bytearray(file.read(read_amount))
         dataset = to_dataset(bytes_in, bits_per_symbol)
         k = len(set(dataset))

--- a/noniid_main.py
+++ b/noniid_main.py
@@ -12,6 +12,7 @@
 # March 3, 2016
 
 
+import os
 import sys
 import time
 import math
@@ -45,7 +46,7 @@ if __name__ == '__main__':
 
     with open(datafile, 'rb') as file:
         # Read in raw bytes and convert to list of output symbols
-        bytes_in = bytearray(file.read(start_position))
+        file.seek(start_position, os.SEEK_SET)
         bytes_in = bytearray(file.read(read_amount))
         dataset = to_dataset(bytes_in, bits_per_symbol)
         k = len(set(dataset))

--- a/noniid_main.py
+++ b/noniid_main.py
@@ -17,7 +17,7 @@ import sys
 import time
 import math
 
-from util90b import get_parser, to_dataset, mapData
+from util90b import get_parser, to_dataset_packed, to_dataset_unpacked, mapData
 from mostCommonValue import most_common
 from noniid_collision import collision_test
 from markov import markov_test
@@ -43,12 +43,16 @@ if __name__ == '__main__':
     verbose = bool(args.verbose)
     start_position = int (args.start_position)
     read_amount = int (args.read_amount)
+    packed = bool (args.packed)
 
     with open(datafile, 'rb') as file:
         # Read in raw bytes and convert to list of output symbols
         file.seek(start_position, os.SEEK_SET)
         bytes_in = bytearray(file.read(read_amount))
-        dataset = to_dataset(bytes_in, bits_per_symbol)
+        if packed:
+          dataset = to_dataset_packed (bytes_in, bits_per_symbol)
+        else:
+          dataset = to_dataset_unpacked (bytes_in, bits_per_symbol)
         k = len(set(dataset))
         if verbose:
             # print file and dataset details

--- a/noniid_main.py
+++ b/noniid_main.py
@@ -40,10 +40,13 @@ if __name__ == '__main__':
     else:
         use_bits = bits_per_symbol
     verbose = bool(args.verbose)
+    start_position = int (args.start_position)
+    read_amount = int (args.read_amount)
 
     with open(datafile, 'rb') as file:
         # Read in raw bytes and convert to list of output symbols
-        bytes_in = bytearray(file.read())
+        bytes_in = bytearray(file.read(start_position))
+        bytes_in = bytearray(file.read(read_amount))
         dataset = to_dataset(bytes_in, bits_per_symbol)
         k = len(set(dataset))
         if verbose:

--- a/permutation_tests.py
+++ b/permutation_tests.py
@@ -354,6 +354,8 @@ def permutation_test(s, verbose=False):
         cs2 = conversion2(s)
 
     t['excursion'] = excursion(s, mean)
+    if verbose:
+      print ("t['excursion'] %s" % (str (t['excursion'])))
     
     if is_binary:
         # conversion 1 required for binary data for directional run and
@@ -367,6 +369,10 @@ def permutation_test(s, verbose=False):
         t['numDirectionalRuns'] = numDirectionalRuns(sp1)
         t['lenDirectionalRuns'] = lenDirectionalRuns(sp1)
         t['numIncreasesDecreases'] = numIncreasesDecreases(sp1)
+    if verbose:
+      print ("t['numDirectionalRuns'] %s" % (str (t['numDirectionalRuns'])))
+      print ("t['lenDirectionalRuns'] %s" % (str (t['lenDirectionalRuns'])))
+      print ("t['numIncreasesDecreases'] %s" % (str (t['numIncreasesDecreases'])))
 
     if is_binary:
         sp2= altSequence2(s, 0.5)
@@ -374,6 +380,9 @@ def permutation_test(s, verbose=False):
         sp2= altSequence2(s, median)
     t['numRunsMedian'] = numRunsMedian(sp2)
     t['lenRunsMedian'] = lenRunsMedian(sp2)
+    if verbose:
+      print ("t['numRunsMedian'] %s" % (str (t['numRunsMedian'])))
+      print ("t['lenRunsMedian'] %s" % (str (t['lenRunsMedian'])))
 
     if is_binary:
         # conversion 2 required for collision statistics on binary data
@@ -382,6 +391,9 @@ def permutation_test(s, verbose=False):
         collision_list = findCollisions(s)
     t['avgCollision'] = avgCollision(collision_list)
     t['maxCollision'] = maxCollision(collision_list)
+    if verbose:
+      print ("t['avgCollision'] %s" % (str (t['avgCollision'])))
+      print ("t['maxCollision'] %s" % (str (t['maxCollision'])))
 
     if is_binary:
         # conversion 1 required for periodicity statistics on binary data
@@ -396,6 +408,12 @@ def permutation_test(s, verbose=False):
         t['periodicity(8)'] = periodicity(s,8)
         t['periodicity(16)'] = periodicity(s,16)
         t['periodicity(32)'] = periodicity(s,32)
+    if verbose:
+      print ("t['periodicity(1)'] %s" % (str (t['periodicity(1)'])))
+      print ("t['periodicity(2)'] %s" % (str (t['periodicity(2)'])))
+      print ("t['periodicity(8)'] %s" % (str (t['periodicity(8)'])))
+      print ("t['periodicity(16)'] %s" % (str (t['periodicity(16)'])))
+      print ("t['periodicity(32)'] %s" % (str (t['periodicity(32)'])))
         
     if is_binary:
         # conversion 1 required for covariance statistics on binary data
@@ -410,18 +428,23 @@ def permutation_test(s, verbose=False):
         t['covariance(8)'] = covariance(s,8)
         t['covariance(16)'] = covariance(s,16)
         t['covariance(32)'] = covariance(s,32)
+    if verbose:
+      print ("t['covariance(1)'] %s" % (str (t['covariance(1)'])))
+      print ("t['covariance(2)'] %s" % (str (t['covariance(2)'])))
+      print ("t['covariance(8)'] %s" % (str (t['covariance(8)'])))
+      print ("t['covariance(16)'] %s" % (str (t['covariance(16)'])))
+      print ("t['covariance(32)'] %s" % (str (t['covariance(32)'])))
         
     t['compression'] = compression(s)
+    if verbose:
+      print ("t['compression'] %s\n" % (str (t['compression'])))
 
     # 2. For j=1 to 10000
         # 2.1 Permute the input data using Fisher-Yates
-    
+
     if verbose:
         print ("Calculating statistics on permuted sequences")
     for j in range(10000):
-        if verbose:
-            sys.stdout.write("\rpermutation tests:\t%.2f percent complete" % (float(j)/100))
-            sys.stdout.flush()
         shuffle(s)
 
         # 2.2 for each test i
@@ -433,72 +456,162 @@ def permutation_test(s, verbose=False):
             cs1 = conversion1(s)
             cs2 = conversion2(s)
 
-        tp['excursion'] = excursion(s, mean)
+        if ((C['excursion'][0]+C['excursion'][1]) <= 5) or (((j + 1) - C['excursion'][0]) <= 5):
+          tp['excursion'] = excursion(s, mean)
         
         if is_binary:
             # conversion 1 required for binary data for directional run and
             # increases/decreases statistics
             sp1 = altSequence1(cs1)
-            tp['numDirectionalRuns'] = numDirectionalRuns(sp1)
-            tp['lenDirectionalRuns'] = lenDirectionalRuns(sp1)
-            tp['numIncreasesDecreases'] = numIncreasesDecreases(sp1)
+            if ((C['numDirectionalRuns'][0]+C['numDirectionalRuns'][1]) <= 5) or (((j + 1) - C['numDirectionalRuns'][0]) <= 5):
+              tp['numDirectionalRuns'] = numDirectionalRuns(sp1)
+            if ((C['lenDirectionalRuns'][0]+C['lenDirectionalRuns'][1]) <= 5) or (((j + 1) - C['lenDirectionalRuns'][0]) <= 5):
+              tp['lenDirectionalRuns'] = lenDirectionalRuns(sp1)
+            if ((C['numIncreasesDecreases'][0]+C['numIncreasesDecreases'][1]) <= 5) or (((j + 1) - C['numIncreasesDecreases'][0]) <= 5):
+              tp['numIncreasesDecreases'] = numIncreasesDecreases(sp1)
         else:
             sp1 = altSequence1(s)
-            tp['numDirectionalRuns'] = numDirectionalRuns(sp1)
-            tp['lenDirectionalRuns'] = lenDirectionalRuns(sp1)
-            tp['numIncreasesDecreases'] = numIncreasesDecreases(sp1)
+            if ((C['numDirectionalRuns'][0]+C['numDirectionalRuns'][1]) <= 5) or (((j + 1) - C['numDirectionalRuns'][0]) <= 5):
+              tp['numDirectionalRuns'] = numDirectionalRuns(sp1)
+            if ((C['lenDirectionalRuns'][0]+C['lenDirectionalRuns'][1]) <= 5) or (((j + 1) - C['lenDirectionalRuns'][0]) <= 5):
+              tp['lenDirectionalRuns'] = lenDirectionalRuns(sp1)
+            if ((C['numIncreasesDecreases'][0]+C['numIncreasesDecreases'][1]) <= 5) or (((j + 1) - C['numIncreasesDecreases'][0]) <= 5):
+              tp['numIncreasesDecreases'] = numIncreasesDecreases(sp1)
 
         if is_binary:
             sp2= altSequence2(s, 0.5)
         else:
             sp2= altSequence2(s, median)
-        tp['numRunsMedian'] = numRunsMedian(sp2)
-        tp['lenRunsMedian'] = lenRunsMedian(sp2)
+        if ((C['numRunsMedian'][0]+C['numRunsMedian'][1]) <= 5) or (((j + 1) - C['numRunsMedian'][0]) <= 5):
+          tp['numRunsMedian'] = numRunsMedian(sp2)
+        if ((C['lenRunsMedian'][0]+C['lenRunsMedian'][1]) <= 5) or (((j + 1) - C['lenRunsMedian'][0]) <= 5):
+          tp['lenRunsMedian'] = lenRunsMedian(sp2)
 
         if is_binary:
             # conversion 2 required for collision statistics on binary data
-            collision_list = findCollisions(cs2)
+            if (((C['avgCollision'][0]+C['avgCollision'][1]) <= 5) or (((j + 1) - C['avgCollision'][0]) <= 5)
+              or ((C['maxCollision'][0]+C['maxCollision'][1]) <= 5) or (((j + 1) - C['maxCollision'][0]) <= 5)):
+              collision_list = findCollisions(cs2)
         else:
-            collision_list = findCollisions(s)
-        tp['avgCollision'] = avgCollision(collision_list)
-        tp['maxCollision'] = maxCollision(collision_list)
+            if (((C['avgCollision'][0]+C['avgCollision'][1]) <= 5) or (((j + 1) - C['avgCollision'][0]) <= 5)
+              or ((C['maxCollision'][0]+C['maxCollision'][1]) <= 5) or (((j + 1) - C['maxCollision'][0]) <= 5)):
+              collision_list = findCollisions(s)
+        if ((C['avgCollision'][0]+C['avgCollision'][1]) <= 5) or (((j + 1) - C['avgCollision'][0]) <= 5):
+          tp['avgCollision'] = avgCollision(collision_list)
+        if ((C['maxCollision'][0]+C['maxCollision'][1]) <= 5) or (((j + 1) - C['maxCollision'][0]) <= 5):
+          tp['maxCollision'] = maxCollision(collision_list)
 
         if is_binary:
             # conversion 1 required for periodicity statistics on binary data
-            tp['periodicity(1)'] = periodicity(cs1,1)
-            tp['periodicity(2)'] = periodicity(cs1,2)
-            tp['periodicity(8)'] = periodicity(cs1,8)
-            tp['periodicity(16)'] = periodicity(cs1,16)
-            tp['periodicity(32)'] = periodicity(cs1,32)
+            if ((C['periodicity(1)'][0]+C['periodicity(1)'][1]) <= 5) or (((j + 1) - C['periodicity(1)'][0]) <= 5):
+              tp['periodicity(1)'] = periodicity(cs1,1)
+            if ((C['periodicity(2)'][0]+C['periodicity(2)'][1]) <= 5) or (((j + 1) - C['periodicity(2)'][0]) <= 5):
+              tp['periodicity(2)'] = periodicity(cs1,2)
+            if ((C['periodicity(8)'][0]+C['periodicity(8)'][1]) <= 5) or (((j + 1) - C['periodicity(8)'][0]) <= 5):
+              tp['periodicity(8)'] = periodicity(cs1,8)
+            if ((C['periodicity(16)'][0]+C['periodicity(16)'][1]) <= 5) or (((j + 1) - C['periodicity(16)'][0]) <= 5):
+              tp['periodicity(16)'] = periodicity(cs1,16)
+            if ((C['periodicity(32)'][0]+C['periodicity(32)'][1]) <= 5) or (((j + 1) - C['periodicity(32)'][0]) <= 5):
+              tp['periodicity(32)'] = periodicity(cs1,32)
         else:
-            tp['periodicity(1)'] = periodicity(s,1)
-            tp['periodicity(2)'] = periodicity(s,2)
-            tp['periodicity(8)'] = periodicity(s,8)
-            tp['periodicity(16)'] = periodicity(s,16)
-            tp['periodicity(32)'] = periodicity(s,32)
+            if ((C['periodicity(1)'][0]+C['periodicity(1)'][1]) <= 5) or (((j + 1) - C['periodicity(1)'][0]) <= 5):
+              tp['periodicity(1)'] = periodicity(s,1)
+            if ((C['periodicity(2)'][0]+C['periodicity(2)'][1]) <= 5) or (((j + 1) - C['periodicity(2)'][0]) <= 5):
+              tp['periodicity(2)'] = periodicity(s,2)
+            if ((C['periodicity(8)'][0]+C['periodicity(8)'][1]) <= 5) or (((j + 1) - C['periodicity(8)'][0]) <= 5):
+              tp['periodicity(8)'] = periodicity(s,8)
+            if ((C['periodicity(16)'][0]+C['periodicity(16)'][1]) <= 5) or (((j + 1) - C['periodicity(16)'][0]) <= 5):
+              tp['periodicity(16)'] = periodicity(s,16)
+            if ((C['periodicity(32)'][0]+C['periodicity(32)'][1]) <= 5) or (((j + 1) - C['periodicity(32)'][0]) <= 5):
+              tp['periodicity(32)'] = periodicity(s,32)
             
         if is_binary:
             # conversion 1 required for covariance statistics on binary data
-            tp['covariance(1)'] = covariance(cs1,1)
-            tp['covariance(2)'] = covariance(cs1,2)
-            tp['covariance(8)'] = covariance(cs1,8)
-            tp['covariance(16)'] = covariance(cs1,16)
-            tp['covariance(32)'] = covariance(cs1,32)
+            if ((C['covariance(1)'][0]+C['covariance(1)'][1]) <= 5) or (((j + 1) - C['covariance(1)'][0]) <= 5):
+              tp['covariance(1)'] = covariance(cs1,1)
+            if ((C['covariance(2)'][0]+C['covariance(2)'][1]) <= 5) or (((j + 1) - C['covariance(2)'][0]) <= 5):
+              tp['covariance(2)'] = covariance(cs1,2)
+            if ((C['covariance(8)'][0]+C['covariance(8)'][1]) <= 5) or (((j + 1) - C['covariance(8)'][0]) <= 5):
+              tp['covariance(8)'] = covariance(cs1,8)
+            if ((C['covariance(16)'][0]+C['covariance(16)'][1]) <= 5) or (((j + 1) - C['covariance(16)'][0]) <= 5):
+              tp['covariance(16)'] = covariance(cs1,16)
+            if ((C['covariance(32)'][0]+C['covariance(32)'][1]) <= 5) or (((j + 1) - C['covariance(32)'][0]) <= 5):
+              tp['covariance(32)'] = covariance(cs1,32)
         else:
-            tp['covariance(1)'] = covariance(s,1)
-            tp['covariance(2)'] = covariance(s,2)
-            tp['covariance(8)'] = covariance(s,8)
-            tp['covariance(16)'] = covariance(s,16)
-            tp['covariance(32)'] = covariance(s,32)
+            if ((C['covariance(1)'][0]+C['covariance(1)'][1]) <= 5) or (((j + 1) - C['covariance(1)'][0]) <= 5):
+              tp['covariance(1)'] = covariance(s,1)
+            if ((C['covariance(2)'][0]+C['covariance(2)'][1]) <= 5) or (((j + 1) - C['covariance(2)'][0]) <= 5):
+              tp['covariance(2)'] = covariance(s,2)
+            if ((C['covariance(8)'][0]+C['covariance(8)'][1]) <= 5) or (((j + 1) - C['covariance(8)'][0]) <= 5):
+              tp['covariance(8)'] = covariance(s,8)
+            if ((C['covariance(16)'][0]+C['covariance(16)'][1]) <= 5) or (((j + 1) - C['covariance(16)'][0]) <= 5):
+              tp['covariance(16)'] = covariance(s,16)
+            if ((C['covariance(32)'][0]+C['covariance(32)'][1]) <= 5) or (((j + 1) - C['covariance(32)'][0]) <= 5):
+              tp['covariance(32)'] = covariance(s,32)
             
-        tp['compression'] = compression(s)
+        if ((C['compression'][0]+C['compression'][1]) <= 5) or (((j + 1) - C['compression'][0]) <= 5):
+          tp['compression'] = compression(s)
         
         # 2.2.2 If (tp[i] > t[i]), increment C[i,0]. If (tp[i] = t[i]), increment C[i,1].
+        pass_flag = True
         for i in get_test_names():
-            if tp[i] > t[i]:
-                C[i][0] += 1
-            elif tp[i] == t[i]:
-                C[i][1] += 1
+            if ((C[i][0]+C[i][1]) <= 5) or (((j + 1) - C[i][0]) <= 5):
+              if tp[i] > t[i]:
+                  C[i][0] += 1
+              elif tp[i] == t[i]:
+                  C[i][1] += 1
+              pass_flag = False
+        if verbose:
+          if ((C['excursion'][0]+C['excursion'][1]) <= 5) or (((j + 1) - C['excursion'][0]) <= 5):
+            print ("t tp ['excursion'] %d  %d  %d" % (t['excursion'], tp['excursion'], t['excursion'] - tp['excursion']))
+          if ((C['numDirectionalRuns'][0]+C['numDirectionalRuns'][1]) <= 5) or (((j + 1) - C['numDirectionalRuns'][0]) <= 5):
+            print ("t tp ['numDirectionalRuns'] %d  %d  %d" % (t['numDirectionalRuns'], tp['numDirectionalRuns'],
+              t['numDirectionalRuns'] - tp['numDirectionalRuns']))
+          if ((C['lenDirectionalRuns'][0]+C['lenDirectionalRuns'][1]) <= 5) or (((j + 1) - C['lenDirectionalRuns'][0]) <= 5):
+            print ("t tp ['lenDirectionalRuns'] %d  %d  %d" % (t['lenDirectionalRuns'], tp['lenDirectionalRuns'],
+              t['lenDirectionalRuns'] - tp['lenDirectionalRuns']))
+          if ((C['numIncreasesDecreases'][0]+C['numIncreasesDecreases'][1]) <= 5) or (((j + 1) - C['numIncreasesDecreases'][0]) <= 5):
+            print ("t tp ['numIncreasesDecreases'] %d  %d  %d" % (t['numIncreasesDecreases'], tp['numIncreasesDecreases'],
+              t['numIncreasesDecreases'] - tp['numIncreasesDecreases']))
+          if ((C['numRunsMedian'][0]+C['numRunsMedian'][1]) <= 5) or (((j + 1) - C['numRunsMedian'][0]) <= 5):
+            print ("t tp ['numRunsMedian'] %d  %d  %d" % (t['numRunsMedian'], tp['numRunsMedian'], t['numRunsMedian'] - tp['numRunsMedian']))
+          if ((C['lenRunsMedian'][0]+C['lenRunsMedian'][1]) <= 5) or (((j + 1) - C['lenRunsMedian'][0]) <= 5):
+            print ("t tp ['lenRunsMedian'] %d  %d  %d" % (t['lenRunsMedian'], tp['lenRunsMedian'], t['lenRunsMedian'] - tp['lenRunsMedian']))
+          if ((C['avgCollision'][0]+C['avgCollision'][1]) <= 5) or (((j + 1) - C['avgCollision'][0]) <= 5):
+            print ("t tp ['avgCollision'] %8.5e  %8.5e  %8.5e" % (t['avgCollision'], tp['avgCollision'], t['avgCollision'] - tp['avgCollision']))
+          if ((C['maxCollision'][0]+C['maxCollision'][1]) <= 5) or (((j + 1) - C['maxCollision'][0]) <= 5):
+            print ("t tp ['maxCollision'] %d  %d  %d" % (t['maxCollision'], tp['maxCollision'], t['maxCollision'] - tp['maxCollision']))
+          if ((C['periodicity(1)'][0]+C['periodicity(1)'][1]) <= 5) or (((j + 1) - C['periodicity(1)'][0]) <= 5):
+            print ("t tp ['periodicity(1)'] %d  %d  %d" % (t['periodicity(1)'], tp['periodicity(1)'], t['periodicity(1)'] - tp['periodicity(1)']))
+          if ((C['periodicity(2)'][0]+C['periodicity(2)'][1]) <= 5) or (((j + 1) - C['periodicity(2)'][0]) <= 5):
+            print ("t tp ['periodicity(2)'] %d  %d  %d" % (t['periodicity(2)'], tp['periodicity(2)'], t['periodicity(2)'] - tp['periodicity(2)']))
+          if ((C['periodicity(8)'][0]+C['periodicity(8)'][1]) <= 5) or (((j + 1) - C['periodicity(8)'][0]) <= 5):
+            print ("t tp ['periodicity(8)'] %d  %d  %d" % (t['periodicity(8)'], tp['periodicity(8)'], t['periodicity(8)'] - tp['periodicity(8)']))
+          if ((C['periodicity(16)'][0]+C['periodicity(16)'][1]) <= 5) or (((j + 1) - C['periodicity(16)'][0]) <= 5):
+            print ("t tp ['periodicity(16)'] %d  %d  %d" % (t['periodicity(16)'], tp['periodicity(16)'], 
+              t['periodicity(16)'] - tp['periodicity(16)']))
+          if ((C['periodicity(32)'][0]+C['periodicity(32)'][1]) <= 5) or (((j + 1) - C['periodicity(32)'][0]) <= 5):
+            print ("t tp ['periodicity(32)'] %d  %d  %d" % (t['periodicity(32)'], tp['periodicity(32)'], 
+              t['periodicity(32)'] - tp['periodicity(32)']))
+          if ((C['covariance(1)'][0]+C['covariance(1)'][1]) <= 5) or (((j + 1) - C['covariance(1)'][0]) <= 5):
+            print ("t tp ['covariance(1)'] %d  %d  %d" % (t['covariance(1)'], tp['covariance(1)'], t['covariance(1)'] - tp['covariance(1)']))
+          if ((C['covariance(2)'][0]+C['covariance(2)'][1]) <= 5) or (((j + 1) - C['covariance(2)'][0]) <= 5):
+            print ("t tp ['covariance(2)'] %d  %d  %d" % (t['covariance(2)'], tp['covariance(2)'], t['covariance(2)'] - tp['covariance(2)']))
+          if ((C['covariance(8)'][0]+C['covariance(8)'][1]) <= 5) or (((j + 1) - C['covariance(8)'][0]) <= 5):
+            print ("t tp ['covariance(8)'] %d  %d  %d" % (t['covariance(8)'], tp['covariance(8)'], t['covariance(8)'] - tp['covariance(8)']))
+          if ((C['covariance(16)'][0]+C['covariance(16)'][1]) <= 5) or (((j + 1) - C['covariance(16)'][0]) <= 5):
+            print ("t tp ['covariance(16)'] %d  %d  %d" % (t['covariance(16)'], tp['covariance(16)'], t['covariance(16)'] - tp['covariance(16)']))
+          if ((C['covariance(32)'][0]+C['covariance(32)'][1]) <= 5) or (((j + 1) - C['covariance(32)'][0]) <= 5):
+            print ("t tp ['covariance(32)'] %d  %d  %d" % (t['covariance(32)'], tp['covariance(32)'], t['covariance(32)'] - tp['covariance(32)']))
+          if ((C['compression'][0]+C['compression'][1]) <= 5) or (((j + 1) - C['compression'][0]) <= 5):
+            print ("t tp ['compression'] %d  %d  %d" % (t['compression'][0], tp['compression'][0], t['compression'][0] - tp['compression'][0]))
+          for i in get_test_names():
+            print ("%25s %8d %8d" % (i, C[i][0], C[i][1]))
+          print ("\n")
+          print("permutation tests:\t%.2f percent complete\n" % (float(j + 1)/100))
+          print ("\n")
+        if pass_flag:  # the permutation criteria have already been met
+          return True
 
     if verbose:
         print("\n                statistic  C[i][0]  C[i][1]")

--- a/restart.py
+++ b/restart.py
@@ -9,6 +9,7 @@
 # Kerry McKay
 # March 3, 2016
 
+import os
 import sys
 import time
 import math
@@ -37,7 +38,7 @@ if __name__ == '__main__':
 
     with open(datafile, 'rb') as file:
         # Read in raw bytes and convert to list of output symbols
-        bytes_in = bytearray(file.read(start_position))
+        file.seek(start_position, os.SEEK_SET)
         bytes_in = bytearray(file.read(read_amount))
         dataset = to_dataset(bytes_in, bits_per_symbol)
         k = len(set(dataset))

--- a/restart.py
+++ b/restart.py
@@ -14,7 +14,7 @@ import sys
 import time
 import math
 
-from util90b import get_parser, to_dataset, get_z
+from util90b import get_parser, to_dataset_packed, to_dataset_unpacked, get_z
 from mostCommonValue import most_common_restart
 
 from collections import Counter
@@ -35,12 +35,16 @@ if __name__ == '__main__':
     H_I = float(args.H_I)
     start_position = int (args.start_position)
     read_amount = int (args.read_amount)
+    packed = bool (args.packed)
 
     with open(datafile, 'rb') as file:
         # Read in raw bytes and convert to list of output symbols
         file.seek(start_position, os.SEEK_SET)
         bytes_in = bytearray(file.read(read_amount))
-        dataset = to_dataset(bytes_in, bits_per_symbol)
+        if packed:
+          dataset = to_dataset_packed (bytes_in, bits_per_symbol)
+        else:
+          dataset = to_dataset_unpacked (bytes_in, bits_per_symbol)
         k = len(set(dataset))
         if verbose:
             # print file and dataset details

--- a/restart.py
+++ b/restart.py
@@ -16,6 +16,7 @@ import math
 from util90b import get_parser, to_dataset, get_z
 from mostCommonValue import most_common_restart
 
+from collections import Counter
 
 # The input file is the row dataset. This program will derive the colomn dataset from the row dataset.
 
@@ -31,10 +32,13 @@ if __name__ == '__main__':
     bits_per_symbol = int(args.bits_per_symbol)
     verbose = bool(args.verbose)
     H_I = float(args.H_I)
+    start_position = int (args.start_position)
+    read_amount = int (args.read_amount)
 
     with open(datafile, 'rb') as file:
         # Read in raw bytes and convert to list of output symbols
-        bytes_in = bytearray(file.read())
+        bytes_in = bytearray(file.read(start_position))
+        bytes_in = bytearray(file.read(read_amount))
         dataset = to_dataset(bytes_in, bits_per_symbol)
         k = len(set(dataset))
         if verbose:
@@ -42,6 +46,12 @@ if __name__ == '__main__':
             print ("Read in file %s, %d bytes long." % (datafile, len(bytes_in)))
             print ("Dataset: %d %d-bit symbols, %d symbols in alphabet." % (len(dataset), bits_per_symbol, k))
             print ("Output symbol values: min = %d, max = %d" % (min(dataset), max(dataset)))
+            for cti in range (10, 1000000, 50000):
+              print ("sample dataset value %d" % (dataset [cti]))
+            tcount = Counter (dataset)
+            tcount = tcount.most_common (10)
+            for pair in tcount:
+              print ("val= %d  count= %d" % (pair [0], pair [1]))
 
         # max min-entropy is -log_2(1/k)
         minEntropy = float(math.log(k,2))
@@ -49,6 +59,7 @@ if __name__ == '__main__':
 
         # make sure that the dataset is the expected size
         # (otherwise, the column dataset won't be created correctly)
+        dataset = dataset [:1000000]
         assert len(dataset) == 1000000
 
     
@@ -57,26 +68,44 @@ if __name__ == '__main__':
 
         # 2. For each row of the matrix, find the frequency of the most
         #    common sample value. Let F_R be the maximum.
+        #    This is an inefficient way to determine the max frequency,
+        #    but it creates and preserves the list of row frequecies
+        #    that can be used for future analysis, so leave it.  
+        #    Also, optimization yields little benefit here.
         if verbose:
             print ("\nRunning sanity check on row dataset:")
-        f = [0 for i in range(1000)]
+        fr = [0] * 1000
+        maxf = 1
         for i in range(1000):
-            f[i] = most_common_restart(dataset[i*1000:(i+1)*1000])
-        F_R = max(f)
+            fr [i] = most_common_restart(dataset[i*1000:(i+1)*1000])
+            if fr [i] >= maxf:
+              maxf = fr [i]
+              if verbose:
+                print ("i %d  max freq %d" % (i, maxf))
+        F_R = max (fr)
         if verbose:
             print ("- F_R: %d" % F_R)
             
         # 3. repeat the sample process for the column matrix. Let F_C be the
         #    maximum.
+        #    This is an inefficient way to determine the max frequency,
+        #    but it creates and preserves the list of column frequecies
+        #    that can be used for future analysis, so leave it.  
+        #    Also, optimization yields little benefit here.
         if verbose:
             print ("Running sanity check on column dataset:")
-        f = [0 for i in range(1000)]
+        fc = [0] * 1000
+        maxf = 1
         for i in range(1000):
             column = []
             for j in range(1000):
                 column.append(dataset[j*1000+i])
-            f[i] = most_common_restart(column)
-        F_C = max(f)
+            fc [i] = most_common_restart(column)
+            if fc [i] >= maxf:
+              maxf = fc [i]
+              if verbose:
+                print ("i %d  max freq %d" % (i, maxf))
+        F_C = max (fc)
         if verbose:
             print ("- F_C: %d" % F_C)
 
@@ -85,13 +114,14 @@ if __name__ == '__main__':
 
         # 5. Let p = 2**-H_I. Find the upper bound U of the (1-alpha)% confidence
         #    interval
-        p = math.pow(2, -H_I)
-        Z = get_z(alpha)
-        U = 1000*p + Z*math.sqrt(1000*p*(1-p))
+        p = math.pow (2, -H_I)
+        Z = get_z (alpha)
+        U = (1000 * p) + (Z * math.sqrt (1000 * p * (1-p)))
         if verbose: 
-##            print ("alpha:", alpha )         
-##            print ("z:",Z)
-            print ("U: %f" % U)
+            print ("    p: %8.5e" % (p))         
+            print ("alpha: %8.5e"% (alpha))         
+            print ("    Z: %8.5e" % (Z))
+            print ("    U: %f" % (U))
 
         # 6. If F is greater than U, the test fails
         if F > U:

--- a/util90b.py
+++ b/util90b.py
@@ -37,6 +37,8 @@ def get_parser(test):
 
     parser.add_argument('-r', '--read', dest='read_amount', type=int, action='store', metavar='read_amount', default='1000000', help='bytes to read from file')
 
+    parser.add_argument('-p', '--packed', dest='packed', action='store_true', default='False', help='treat input data as packed')
+
     return parser
 
 # Convert a bytearray of raw bytes to a list containing the dataset
@@ -46,7 +48,7 @@ def get_parser(test):
 # not packed (i.e., 8 1-bit output samples are not packed into 1 byte)
 #
 # Does not handle > 8 bits per symbol.
-def to_dataset(bytes, bits_per_symbol):
+def to_dataset_packed (bytes, bits_per_symbol):
     assert bits_per_symbol > 0
     assert bits_per_symbol <= 8
 
@@ -61,6 +63,28 @@ def to_dataset(bytes, bits_per_symbol):
         work_bin = work_bin [bits_per_symbol:]
         converted_bytes.append (new_int)
     return converted_bytes
+
+# Convert a bytearray of raw bytes to a list containing the dataset
+# Use bits-per-symbol to do the mapping
+#
+# Note that 1 bit per symbol assumes that 1 bit per byte is used, the data is
+# not packed (i.e., 8 1-bit output samples are not packed into 1 byte)
+#
+# Does not handle > 8 bits per symbol.
+def to_dataset_unpacked (bytes, bits_per_symbol):
+    assert bits_per_symbol > 0
+    assert bits_per_symbol <= 8
+
+    # mask for relevant bits
+    mask = 2**bits_per_symbol - 1
+
+    N = len(bytes)
+    print ("reading %d bytes of data" % N)
+
+    if bits_per_symbol <= 8: # includes 1-bit per symbol
+        return [b & mask for b in bytes]
+    else:
+        return list()
 
 
 

--- a/util90b.py
+++ b/util90b.py
@@ -33,6 +33,10 @@ def get_parser(test):
         
     parser.add_argument('-v', '--verbose', dest='verbose', action='store_true', help='verbose mode: show detailed test results')
 
+    parser.add_argument('-s', '--start', dest='start_position', metavar='start_position', help='start byte position in file')
+
+    parser.add_argument('-r', '--read', dest='read_amount', metavar='read_amount', help='bytes to read from file')
+
     return parser
 
 # Convert a bytearray of raw bytes to a list containing the dataset
@@ -46,16 +50,21 @@ def to_dataset(bytes, bits_per_symbol):
     assert bits_per_symbol > 0
     assert bits_per_symbol <= 8
 
-    # mask for relevant bits
-    mask = 2**bits_per_symbol - 1
+    print ("converting %d bytes of data to ints using %d bits per int" % (len (bytes), bits_per_symbol))
+    converted_bytes = []
+    work_bin = ''
+    for byte in bytes:
+      byte_bin = bin (int (byte))
+      byte_bin = byte_bin [2:]
+      while len (byte_bin) < 8:
+        byte_bin = '0' + byte_bin
+      work_bin += byte_bin
+      while len (work_bin) >= bits_per_symbol:
+        new_int = int (work_bin [:bits_per_symbol], 2)
+        work_bin = work_bin [bits_per_symbol:]
+        converted_bytes.append (new_int)
+    return converted_bytes
 
-    N = len(bytes)
-    print ("reading %d bytes of data" % N)
-
-    if bits_per_symbol <= 8: # includes 1-bit per symbol
-        return [b & mask for b in bytes]
-    else:
-        return list()
 
 
 # Map dataset to list 0..n. This is necessary for datasets here k is not
@@ -125,6 +134,8 @@ def get_z(alpha):
                 5E-08: 5.451310443,
                 1.95312E-08: 5.61610279}
     
+    keys = list (z_values.keys ())
+    keys.sort ()
     if alpha in z_values.keys():
         return z_values[alpha]
     else:

--- a/util90b.py
+++ b/util90b.py
@@ -24,18 +24,18 @@ def get_parser(test):
     descr = 'Run the Draft NIST SP 800-90B (January 2016) %s Tests' % test
     parser = argparse.ArgumentParser(description=descr)
     parser.add_argument(dest='datafile', metavar='datafile', help='dataset on which to run tests')
-    parser.add_argument(dest='bits_per_symbol',metavar='bits_per_symbol', help='number of bits used to represent sample output values')
+    parser.add_argument('-b', '--bits', dest='bits_per_symbol', type=int, action='store', metavar='bits_per_symbol', default='8', help='number of bits used to represent sample output values')
 
     if test == 'non-IID':
-        parser.add_argument('-u', '--usebits', dest='use_bits', metavar='use_bits', help='use only the N lowest order bits per sample')
+        parser.add_argument('-u', '--usebits', dest='use_bits', type=int, action='store', metavar='use_bits', default='0', help='use only the N lowest order bits per sample')
     elif test == 'restart':
-        parser.add_argument(dest='H_I', metavar='H_I', help='initial entropy estimate')
+        parser.add_argument('-e', '--entropy', dest='H_I', type=float, action='store', metavar='H_I', required=True,  help='initial entropy estimate')
         
     parser.add_argument('-v', '--verbose', dest='verbose', action='store_true', help='verbose mode: show detailed test results')
 
-    parser.add_argument('-s', '--start', dest='start_position', metavar='start_position', help='start byte position in file')
+    parser.add_argument('-s', '--start', dest='start_position', type=int, action='store', metavar='start_position', default='0', help='start byte position in file')
 
-    parser.add_argument('-r', '--read', dest='read_amount', metavar='read_amount', help='bytes to read from file')
+    parser.add_argument('-r', '--read', dest='read_amount', type=int, action='store', metavar='read_amount', default='1000000', help='bytes to read from file')
 
     return parser
 
@@ -54,10 +54,7 @@ def to_dataset(bytes, bits_per_symbol):
     converted_bytes = []
     work_bin = ''
     for byte in bytes:
-      byte_bin = bin (int (byte))
-      byte_bin = byte_bin [2:]
-      while len (byte_bin) < 8:
-        byte_bin = '0' + byte_bin
+      byte_bin = format (byte, '08b')
       work_bin += byte_bin
       while len (work_bin) >= bits_per_symbol:
         new_int = int (work_bin [:bits_per_symbol], 2)


### PR DESCRIPTION
…ncy of permutation check

Lots of changes here.

I increased the verbose output in permutation_tests.py.  It's now possible to monitor what is happening as the permutation tests are run.

I changed the tests in permutation_tests.py so that when the pass criteria are met, the test ends.  I changed the tests in permutation_tests.py so that when a test has passed, it no longer is computed.  These two changes mean that the permutation tests are *much* faster.

I increased the output of restart.py under verbose.

I altered the row and column frequency selection in restart.py so that the results are saved in case future analysis is desired.

I changed to_data in util90b.py so that packed data is used.  This allows bit sizes of greater than 8 bits, but their use is curtailed because the rest of the programs don't deal well with the larger size.  I did get a 9 bit sample size to pass the restart tests.

I added two new variables to the arguments list in the parser in util90b.py.  They are a start_position and read_amount.  The start_position is where to start reading random data in the file, and the read_amount is how many bytes to read.  This allows a larger file to be processed in chunks, so that restart can still be run on the output.

I modified iid_main.py, noniid_main.py, and restart.py to utilize the start_position and read_amount parameters.