### PR TITLE
Unbias the shuffle RNG

### DIFF
--- a/cpp/shared/utils.h
+++ b/cpp/shared/utils.h
@@ -49,7 +49,12 @@ void shuffle(byte arr[]){
 	long int r;
 
 	for(long int i = SIZE-1; i > 0; --i){
-		r = (rand() / (float)RAND_MAX) * (i+1); 	// Proven faster than using % to cast random values
+		/* Generate an unbiassed integer in the interval [0, i] */
+        	const long int mx = (RAND_MAX / (i+1)) * (i+1);
+		do
+			r = rand();
+		while (r >= mx);
+		r %= i+1;
 		SWAP(arr[r], arr[i]);
 	}
 }


### PR DESCRIPTION
The Fisher-Yates shuffle algorithm is using a biased algorithm to generate the random swap position.  This pull request modifies this so the position is unbiased.

The current code produces biased output when i+1 isn't a divisor of `RAND_MAX`.  This is most of the time.
