### PR TITLE
Compression estimate fix and a grab bag of scientific computing updates.

### DIFF
--- a/cpp/non_iid/collision_test.h
+++ b/cpp/non_iid/collision_test.h
@@ -82,13 +82,15 @@ double collision_test(byte* data, long len){
 
                 //invariant. If this isn't true, then we can't evaluate here.
                 if(!(INCLOSEDINTERVAL(lbound, ldomain, hdomain) && INCLOSEDINTERVAL(hbound,  ldomain, hdomain))) {
-                        p = hdomain;
+			//This is a search failure (as directed in step #8)
+                        p = 0.5;
                         break;
                 }
 
                 //invariant. If this isn't true, then seeking the value within this interval doesn't make sense.
                 if(!INCLOSEDINTERVAL(X, lvalue, hvalue)) {
-                        p = hdomain;
+			//This is a search failure (as directed in step #8)
+                        p = 0.5;
                         break;
                 }
 

--- a/cpp/non_iid/collision_test.h
+++ b/cpp/non_iid/collision_test.h
@@ -82,15 +82,15 @@ double collision_test(byte* data, long len){
 
                 //invariant. If this isn't true, then we can't evaluate here.
                 if(!(INCLOSEDINTERVAL(lbound, ldomain, hdomain) && INCLOSEDINTERVAL(hbound,  ldomain, hdomain))) {
-			//This is a search failure (as directed in step #8)
-                        p = 0.5;
+			//This is a search failure. We need to return "full entropy"  (as directed in step #8).
+                        p = ldomain;
                         break;
                 }
 
                 //invariant. If this isn't true, then seeking the value within this interval doesn't make sense.
                 if(!INCLOSEDINTERVAL(X, lvalue, hvalue)) {
-			//This is a search failure (as directed in step #8)
-                        p = 0.5;
+			//This is a search failure. We need to return "full entropy"  (as directed in step #8).
+                        p = ldomain;
                         break;
                 }
 

--- a/cpp/non_iid/collision_test.h
+++ b/cpp/non_iid/collision_test.h
@@ -3,19 +3,7 @@
 
 // Computed using efficient implementation in Appendix G.1.1
 double F(double q){
-	int i;	
-	double z, ret;
-	
-	i = 1000;
-	z = 1.0/q;
-	ret = z + (i-2.0)/(i+1.0);
-	
-	while(i > 0){
-		i--;
-		ret = z + (i-2.0) / (1.0 + ((i+1.0)/ret));
-	}
-
-	return  1.0/ret;
+   return q*(2.0*q*q+2.0*q+1.0);
 }
 
 double col_exp(double p, double q){
@@ -25,10 +13,13 @@ double col_exp(double p, double q){
 // Section 6.3.2 - Collision Estimate
 // data is assumed to be binary (e.g., bit string)
 double collision_test(byte* data, long len){
-	long v, i;
+	long v, i, j;
 	int t_v;
-	double X, s, p, p_hi, p_lo, eps, exp;
-	
+	double X, s, p, lastP, pVal;
+        double lvalue, hvalue;
+        double hbound, lbound;
+        double hdomain, ldomain;
+
 	i = 0;
 	v = 0;
 	X = 0.0;
@@ -51,24 +42,84 @@ double collision_test(byte* data, long len){
 	s = sqrt((s - (i*X)) / (v-1));
 
 	// binary search for p
-	X -= 2.576 * s/sqrt(v);
-	eps = 1.0 / (1 << 20); // 2^-20
-	p_lo = 0.5;
-	p_hi = 1.0 - eps; // avoid division by zero
-	do{
-		p = (p_lo + p_hi) / 2.0;
-		exp = col_exp(p, 1.0-p);
+	X -= ZALPHA * s/sqrt(v);
 
-		if(X < exp) p_lo = p;
-		else p_hi = p;
+	ldomain = 0.5;
+        hdomain = 1.0;
 
-		if((col_exp(p_lo, 1.0-p_lo) < X) || (col_exp(p_hi, 1.0-p_hi) > X)){
-			// binary search failed, settle for one bit of entropy
-			printf("\t *** WARNING: binary search for collision test failed ***\n");
-			p = 0.5; 
-			break;
-		}
-	}while(fabs(p_hi - p_lo) > eps);
+        lbound = ldomain;
+        hbound = hdomain;
+
+        lvalue = DBL_INFINITY;
+        hvalue = -DBL_INFINITY;
+
+        //Note that the bounds are in [0,1], so overflows aren't an issue
+        //But underflows are.
+        p = (lbound + hbound) / 2.0;
+	pVal = col_exp(p, 1.0-p);
+
+        //We don't need the initial pVal invariant, as our initial bounds are infinite.
+        //We don't need the initial bounds, as they are set to the domain bounds
+        for(j=0; j<ITERMAX; j++) {
+                //Have we reached "equality"?
+                if(relEpsilonEqual(pVal, X, ABSEPSILON, RELEPSILON, 4)) break;
+
+                //Now update based on the found pVal
+                if(X < pVal) {
+                        lbound = p;
+                        lvalue = pVal;
+                } else {
+                        hbound = p;
+                        hvalue = pVal;
+                }
+
+                //We now verify that ldomain <= lbound < p < hbound <= hdomain
+                //and that target in [ lvalue, hvalue ]
+                if(lbound >= hbound) {
+                        p = fmin(fmax(lbound, hbound),hdomain);
+                        break;
+                }
+
+                //invariant. If this isn't true, then we can't evaluate here.
+                if(!(INCLOSEDINTERVAL(lbound, ldomain, hdomain) && INCLOSEDINTERVAL(hbound,  ldomain, hdomain))) {
+                        p = hdomain;
+                        break;
+                }
+
+                //invariant. If this isn't true, then seeking the value within this interval doesn't make sense.
+                if(!INCLOSEDINTERVAL(X, lvalue, hvalue)) {
+                        p = hdomain;
+                        break;
+                }
+
+                //Update p
+                lastP = p;
+                p = (lbound + hbound) / 2.0;
+
+                //invariant. If this isn't true, then further calculation isn't really meaningful.
+                if(!INOPENINTERVAL(p,  lbound, hbound)) {
+                        p = hbound;
+                        break;
+                }
+
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wfloat-equal"
+                //Look for a cycle
+                if(lastP == p) {
+                        p = hbound;
+                        break;
+                }
+#pragma GCC diagnostic pop
+
+		pVal = col_exp(p, 1.0-p);
+
+                //invariant: If this isn't true, then this isn't loosly monotonic
+                if(!INCLOSEDINTERVAL(pVal, lvalue, hvalue)) {
+                        p = hbound;
+                        break;
+                }
+        }//for loop
 
 	return -log2(p);
 }

--- a/cpp/non_iid/compression_test.h
+++ b/cpp/non_iid/compression_test.h
@@ -20,7 +20,7 @@ double G(double z, long v, int d, long num_blocks){
 }
 
 double com_exp(double p, double q, unsigned int alph_size, long v, int d, long num_blocks){
-        return G(p, v, d, num_blocks) + alph_size * G(q, v, d, num_blocks);
+        return G(p, v, d, num_blocks) + (alph_size - 1) * G(q, v, d, num_blocks);
 }
 
 // Section 6.3.4 - Compression Estimate
@@ -71,12 +71,12 @@ double compression_test(byte* data, long len){
         p_hi = 1.0 - eps; // avoid division by zero
         do{
                 p = (p_lo + p_hi) / 2.0;
-                exp = com_exp(p, (1.0-p)/alph_size, alph_size, v, d, num_blocks);
+                exp = com_exp(p, (1.0-p)/(alph_size-1), alph_size, v, d, num_blocks);
 
                 if(X < exp) p_lo = p;
                 else p_hi = p;
 
-                if((com_exp(p_lo, (1.0-p_lo)/alph_size, alph_size, v, d, num_blocks) < X) || (com_exp(p_hi, (1.0-p_hi)/alph_size, alph_size, v, d, num_blocks) > X)){
+                if((com_exp(p_lo, (1.0-p_lo)/(alph_size-1), alph_size, v, d, num_blocks) < X) || (com_exp(p_hi, (1.0-p_hi)/(alph_size-1), alph_size, v, d, num_blocks) > X)){
                         // binary search failed, settle for one bit of entropy
 			printf("\t *** WARNING: binary search for compression test failed ***\n");
                         p = 1.0/alph_size; 

--- a/cpp/non_iid/compression_test.h
+++ b/cpp/non_iid/compression_test.h
@@ -106,13 +106,15 @@ double compression_test(byte* data, long len){
 
                 //invariant. If this isn't true, then we can't evaluate here.
                 if(!(INCLOSEDINTERVAL(lbound, ldomain, hdomain) && INCLOSEDINTERVAL(hbound,  ldomain, hdomain))) {
-                        p = hdomain;
+			//This is a search failure. We need to return "full entropy"  (as directed in step #8).
+			p = ldomain;
                         break;
                 }
 
                 //invariant. If this isn't true, then seeking the value within this interval doesn't make sense.
                 if(!INCLOSEDINTERVAL(X, lvalue, hvalue)) {
-                        p = hdomain;
+			//This is a search failure. We need to return "full entropy"  (as directed in step #8).
+			p = ldomain;
                         break;
                 }
 

--- a/cpp/non_iid/tuple.h
+++ b/cpp/non_iid/tuple.h
@@ -49,7 +49,7 @@ double t_tuple_test(byte *data, long len, int alph_size, long *u_p){
 	*u_p = tup_size; // set start tuple size 'u' for LRS test
 
 	pmax = pow(2.0, -t_tuple_min_entropy);
-	return -log2(min(1.0, pmax + 2.576*sqrt(pmax*(1.0-pmax)/(len-1.0))));
+	return -log2(min(1.0, pmax + ZALPHA*sqrt(pmax*(1.0-pmax)/(len-1.0))));
 }
 
 // Section 6.3.6 - Longest Repeated Substring (LRS) Estimate
@@ -108,5 +108,5 @@ double lrs_test(byte *data, long len, int alph_size, long u){
 	}
 
 	pmax = pow(2.0, -lrs_min_entropy);
-	return -log2(min(1.0, pmax + 2.576*sqrt(pmax*(1.0-pmax)/(len-1.0))));
+	return -log2(min(1.0, pmax + ZALPHA*sqrt(pmax*(1.0-pmax)/(len-1.0))));
 }

--- a/cpp/shared/most_common.h
+++ b/cpp/shared/most_common.h
@@ -17,7 +17,7 @@ double most_common(byte* data, const long len, const int alph_size){
 	}
 
 	pmax = mode/(double)len;
-	ubound = pmax + 2.576*sqrt(pmax*(1.0-pmax)/(len-1.0));
+	ubound = pmax + ZALPHA*sqrt(pmax*(1.0-pmax)/(len-1.0));
 
 	return -log2(min(1.0, ubound));
 }

--- a/cpp/shared/utils.h
+++ b/cpp/shared/utils.h
@@ -446,7 +446,7 @@ double calc_p_local(long max_run_len, long N){
 
 	q = 1.0-p;
 	x = 1.0;
-	for(i = 0; i < 10; i++) x = 1.0 + q*pow(p, r)*powl(x, r+1.0);
+	for(i = 0; i < 10; i++) x = 1.0 + q*powl(p, r)*powl(x, r+1.0);
 	pVal = (double)(logl(1.0-p*x) - logl((r+1.0-r*x)*q) - (N+1.0)*logl(x));
 
 	//We don't need the initial pVal invariant, as our initial bounds are infinite.
@@ -504,7 +504,7 @@ double calc_p_local(long max_run_len, long N){
 
 		q = 1.0-p;
 		x = 1.0;
-		for(i = 0; i < 10; i++) x = 1.0 + q*pow(p, r)*pow(x, r+1.0);
+		for(i = 0; i < 10; i++) x = 1.0 + q*powl(p, r)*powl(x, r+1.0);
 		pVal = log(1.0-p*x) - log((r+1.0-r*x)*q) - (N+1.0)*log(x);
 
 		//invariant: If this isn't true, then this isn't loosly monotonic


### PR DESCRIPTION
Fixes use of alph_size to be consistent with SP800-90B specification of the compression estimate. Resolves usnistgov/SP800-90B_EntropyAssessment#49