### PR TITLE
make restart_main.cpp compilable via Makefile target

### DIFF
--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -21,6 +21,10 @@ non_iid: non_iid_main.o
 non_iid_main.o: non_iid_main.cpp
 	$(CXX) $(CXXFLAGS) $(LIB) $(INC) non_iid_main.cpp -o ea_non_iid
 
+restart: restart_main.o
+restart_main.o: restart_main.cpp
+	$(CXX) $(CXXFLAGS) $(LIB) $(INC) restart_main.cpp -o ea_restart
+
 run_iid:
 	./ea_iid ../bin/truerand_8bit.bin 8 -i -t -v
 

--- a/cpp/restart_main.cpp
+++ b/cpp/restart_main.cpp
@@ -102,10 +102,10 @@ int main(int argc, char* argv[]){
                 exit(-1);
         }
 
-	if(data.len > SIZE) data.len = SIZE;
+	if(data.len > MIN_SIZE) data.len = MIN_SIZE;
 	if(verbose) printf("Number of Symbols: %ld\n", data.len);
-	if(data.len < SIZE){ 
-		printf("\n*** Error: data contains less than %d samples ***\n\n", SIZE);
+	if(data.len < MIN_SIZE){ 
+		printf("\n*** Error: data contains less than %d samples ***\n\n", MIN_SIZE);
 		exit(-1);
 	}
 	if(verbose){


### PR DESCRIPTION
This pull request adds a target to the Makefile which compiles restart_main.cpp in the same way as the other binaries. This fixes #73.

Additionally it fixes a naming issue of the constant `SIZE` which lead to a compilation error. This fixes #74.