### PR TITLE
First round of permutation test fixes

### DIFF
--- a/cpp/iid/chi_square_tests.h
+++ b/cpp/iid/chi_square_tests.h
@@ -479,7 +479,7 @@ void goodness_of_fit(byte** subset_data, double &score, int &df, const int sampl
 	df = 9*(bins.size()-1);
 }
 
-bool chi_square_tests(const byte data[], const double mean, const double median, const int sample_size, const int alphabet_size, const bool verbose){
+bool chi_square_tests(const byte data[], const int sample_size, const int alphabet_size, const bool verbose){
 
 	double score = 0.0;
 	int df = 0;

--- a/cpp/iid/permutation_tests.h
+++ b/cpp/iid/permutation_tests.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <stdlib.h>
-#include "bzlib.h" // sudo apt-get install libbz2-dev
+#include <bzlib.h> // sudo apt-get install libbz2-dev
 #include "../shared/utils.h"
 
 // The tests used
@@ -115,6 +115,9 @@ vector<int> alt_sequence2(const byte data[], const double median, const int samp
 // Requires data from alt_sequence2
 unsigned int num_directional_runs(const vector<int> &alt_seq){
 	unsigned int num_runs = 0;
+
+	//Account for the first run (which always exists for non-empty strings)
+	if(alt_seq.size() > 0) num_runs ++;
 
 	// openmp optimization
 	#pragma omp parallel for reduction(+:num_runs)
@@ -289,8 +292,7 @@ unsigned long int covariance(const byte data[], const unsigned int p, const unsi
 unsigned int compression(const byte data[], const int sample_size){
 	
 	// Build string of bytes
-	string msg = "";
-	msg.resize(sample_size * 2);	// no more copying string internally again and again after capacity is hit. It still happens but less frequently early on
+	string msg;
 	char buffer[8];
 
 	for(unsigned int i = 0; i < sample_size; ++i){
@@ -303,7 +305,7 @@ unsigned int compression(const byte data[], const int sample_size){
 
 	// Set up structures for compression
 	char* source = (char*)msg.c_str();
-	unsigned int dest_len = 2*sample_size;
+	unsigned int dest_len = ceil(1.01*strlen(source)) + 600;
 	char* dest = new char[dest_len];
 
 	// Compress and capture the size of the compressed data

--- a/cpp/iid/permutation_tests.h
+++ b/cpp/iid/permutation_tests.h
@@ -295,6 +295,9 @@ unsigned int compression(const byte data[], const int sample_size){
 	string msg;
 	char buffer[8];
 
+	//Reserve the necessary size sample_size*(floor(log10(2^8))+1)
+	msg.reserve(4*sample_size);
+
 	for(unsigned int i = 0; i < sample_size; ++i){
 		sprintf(buffer, "%u ", data[i]);
 		msg += buffer;

--- a/cpp/iid/permutation_tests.h
+++ b/cpp/iid/permutation_tests.h
@@ -519,7 +519,7 @@ bool permutation_tests(const data_t *dp, const double rawmean, const double medi
 			cout << "\rPermutation Test: " << divide(i, PERMS)*100 << "% complete" << flush;
 		}
 
-		FYshuffle(data, rawdata, dp->len);
+		FYshuffle(data, rawdata, dp->len, xoshiro256starstarSeed);
 		run_tests(dp, data, rawdata, rawmean, median, tp);
 
 		// Aggregate results into the counters

--- a/cpp/iid_main.cpp
+++ b/cpp/iid_main.cpp
@@ -44,7 +44,7 @@ int main(int argc, char* argv[]){
 
 	bool initial_entropy, all_bits, verbose = false;
 	const char verbose_flag = 'v';
-	double mean, median;
+	double rawmean, median;
 	char* file_path;
 	int num_threads = 4;
 	data_t data;
@@ -125,10 +125,10 @@ int main(int argc, char* argv[]){
 	int sample_size = data.len;
 
 	printf("Calculating baseline statistics...\n");
-	calc_stats(data.symbols, mean, median, sample_size, alphabet_size);
+	calc_stats(&data, rawmean, median);
 
 	if(verbose){
-		printf("\tMean: %f\n", mean);
+		printf("\tRaw Mean: %f\n", rawmean);
 		printf("\tMedian: %f\n", median);
 		printf("\tBinary: %s\n\n", (alphabet_size == 2 ? "true" : "false"));
 	}
@@ -140,7 +140,7 @@ int main(int argc, char* argv[]){
 	printf("min-entropy = %f\n\n", H_min);
 
 	// Compute chi square stats
-	bool chi_square_test_pass = chi_square_tests(data.symbols, mean, median, sample_size, alphabet_size, verbose);
+	bool chi_square_test_pass = chi_square_tests(data.symbols, sample_size, alphabet_size, verbose);
 
 	if(chi_square_test_pass){
 		printf("** Passed chi square tests\n\n");
@@ -160,7 +160,7 @@ int main(int argc, char* argv[]){
 	}
 
 	// Compute permutation stats
-	bool perm_test_pass = permutation_tests(data.symbols, mean, median, alphabet_size, sample_size, num_threads, verbose);
+	bool perm_test_pass = permutation_tests(&data, rawmean, median, num_threads, verbose);
 
 	if(perm_test_pass){
 		printf("** Passed IID permutation tests\n\n");

--- a/cpp/shared/utils.h
+++ b/cpp/shared/utils.h
@@ -323,7 +323,7 @@ uint64_t randomRange64(uint64_t s, uint64_t *xoshiro256starstarState){
 }
 
 // Fisher-Yates Fast (in place) shuffle algorithm
-void FYshuffle(byte data[], byte rawdata[], const int sample_size) {
+void FYshuffle(byte data[], byte rawdata[], const int sample_size, uint64_t *xoshiro256starstarState) {
 	long int r;
 	static mutex shuffle_mutex;
 	unique_lock<mutex> lock(shuffle_mutex);


### PR DESCRIPTION
This pull request resolves an "off by 1" problem for counting runs and a couple of problems in the compression permutation test (a string construction problem and a buffer length problem).

I'm still seeing mismatches in the tests that aren't invariant under translation, so that problem could also be masking other problems.

As of Oct 1, this pull request Closes #78, closes #79, closes #82, closes #61.