### PR TITLE
Allow permtesting large data sets, command line processing fixes.

### DIFF
--- a/cpp/conditioning_main.cpp
+++ b/cpp/conditioning_main.cpp
@@ -4,7 +4,9 @@
 #include <cmath>
 #include <algorithm>
 
-void print_usage(){
+#include <getopt.h>
+
+[[ noreturn ]] void print_usage(){
 	printf("Usage is: ea_conditioning <n_in> <n_out> <nw> <h_in> <-v|-n> <h'>\n\n");
 	printf("\t <n_in>: input number of bits to conditioning function.\n");
 	printf("\t <n_out>: output number of bits from conditioning function.\n");
@@ -20,74 +22,72 @@ void print_usage(){
 	printf("\t\t h_out = min(Output_Entropy(n_in, n_out, nw, h_in), 0.999*n_out, h'*n_out)\n\n");
 	printf("\t as stated in Section 3.1.5.2.\n");
 	printf("\n");
+	exit(-1);
 }
 
 int main(int argc, char* argv[]){
 	bool vetted;
 	double h_p, h_in, h_out, n_in, n_out, nw, n, p_high, p_low, psi, omega, output_entropy, power_term;
+	int opt;
+
+	vetted = true;
+
+        while ((opt = getopt(argc, argv, "vn")) != -1) {
+                switch(opt) {
+                        case 'v':
+                                vetted = true;
+                                break;
+                        case 'n':
+                                vetted = false;
+                                break;
+                        default:
+                                print_usage();
+                                break;
+                }
+        }
+
+        argc -= optind;
+        argv += optind;
 
 	// Parse args
-	if(argc != 6 && argc != 7){
+	if((vetted && (argc != 4)) || (!vetted && (argc != 5))){
 		printf("Incorrect usage.\n");
 		print_usage();
-		exit(-1);
 	}
 	else{
-
                 // get n_in     
-                n_in = atof(argv[1]);
-                if(n_in <= 0){
-                        printf("n_in must be positive.\n");
+                n_in = atof(argv[0]);
+                if((n_in <= 0) || (floor(n_in) != n_in)){
+                        printf("n_in must be a positive integer.\n");
                         print_usage();
-                        exit(-1);
                 }
 
 	    	// get n_out     
-                n_out = atof(argv[2]);
-                if(n_out <= 0){
-                        printf("n_out must be positive.\n");
+                n_out = atof(argv[1]);
+                if((n_out <= 0) || (floor(n_out) != n_out)){
+                        printf("n_out must be a positive integer.\n");
                         print_usage();
-                        exit(-1);
                 }
 
                 // get n_out     
-                nw = atof(argv[3]);
-                if(nw <= 0){
-                        printf("n_out must be positive.\n");
+                nw = atof(argv[2]);
+                if((nw <= 0) || (floor(nw) != nw)){
+                        printf("n_out must be a positive integer.\n");
                         print_usage();
-                        exit(-1);
                 }
 
                 // get h_in     
-                h_in = atof(argv[4]);
+                h_in = atof(argv[3]);
                 if((h_in <= 0) || (h_in > n_in)){
                         printf("h_in must be positive and at most n_in.\n");
                         print_usage();
-                        exit(-1);
-                }
-
-                // get vetted or non-vetted conditioning function
-                if(argv[5][1] == 'v') vetted = true;
-                else if(argv[5][1] == 'n') vetted = false;
-                else{
-                        printf("Must specify whether conditioning function is vetted or non-vetted.\n");
-                        print_usage();
-                        exit(-1);
                 }
 
 		if(!vetted){
-			if(argc == 7){
-				h_p = atof(argv[6]);
-				if((h_p < 0) || (h_p > 1.0)){
-					printf("h' must be between 0 and 1 inclusive.\n");
-					print_usage();
-					exit(-1);
-				}
-			}
-			else{
-				printf("Must specify h' for non-vetted conditioning function.\n");
+			h_p = atof(argv[4]);
+			if((h_p < 0) || (h_p > 1.0)){
+				printf("h' must be between 0 and 1 inclusive.\n");
 				print_usage();
-        	                exit(-1);
 			}
 		}
 	}

--- a/cpp/conditioning_main.cpp
+++ b/cpp/conditioning_main.cpp
@@ -7,7 +7,7 @@
 #include <getopt.h>
 
 [[ noreturn ]] void print_usage(){
-	printf("Usage is: ea_conditioning <n_in> <n_out> <nw> <h_in> <-v|-n> <h'>\n\n");
+	printf("Usage is: ea_conditioning <-v|-n> <n_in> <n_out> <nw> <h_in> <h'>\n\n");
 	printf("\t <n_in>: input number of bits to conditioning function.\n");
 	printf("\t <n_out>: output number of bits from conditioning function.\n");
 	printf("\t <nw>: narrowest internal width of conditioning function.\n");

--- a/cpp/iid_main.cpp
+++ b/cpp/iid_main.cpp
@@ -4,8 +4,9 @@
 #include "iid/permutation_tests.h"
 #include "iid/chi_square_tests.h"
 #include <omp.h>
+#include <getopt.h>
 
-void print_usage(){
+[[ noreturn ]] void print_usage(){
 	printf("Usage is: ea_iid <file_name> <bits_per_word> <-i|-c> <-a|-t> [-v]\n\n");
 	printf("\t <file_name>: Must be relative path to a binary file with at least 1 million entries (words).\n");
 	printf("\t <bits_per_word>: Must be between 1-8, inclusive.\n");
@@ -39,56 +40,62 @@ void print_usage(){
 	printf("\t\t conditioning function is non-vetted. The samples are converted to a bitstring.\n");
 	printf("\t\t Returns h' = min(H_bitstring).\n");
 	printf("\n");
+	exit(-1);
 }
 
 int main(int argc, char* argv[]){
 
 	bool initial_entropy, all_bits, verbose = false;
-	const char verbose_flag = 'v';
 	double rawmean, median;
 	char* file_path;
 	data_t data;
+	int opt;
+
+	initial_entropy = true;
+	all_bits = true;
+	verbose = false;
+
+	while ((opt = getopt(argc, argv, "icatv")) != -1) {
+		switch(opt) {
+			case 'i':
+				initial_entropy = true;
+				break;
+			case 'c':
+				initial_entropy = false;
+				break;
+			case 'a':
+				all_bits = true;
+				break;
+			case 't':
+				all_bits = false;
+				break;
+			case 'v':
+				verbose = true;
+				break;
+			default:
+				print_usage();
+				break;
+		}
+	}
+
+	argc -= optind;
+	argv += optind;
 
 	// Parse args
-	if(argc < 6){
+	if(argc != 2){
 		printf("Incorrect usage.\n");
 		print_usage();
-		exit(-1);
 	}else{
 
 		// Gather filename
-		file_path = argv[1];
+		file_path = argv[0];
 
 		// Gather bits per word
-		data.word_size = atoi(argv[2]);
+		data.word_size = atoi(argv[1]);
 		if(data.word_size < 1 || data.word_size > 8){
 			printf("Invalid bits per word.\n");
 			print_usage();
-			exit(-1);
 		}
-
-		// get initial entropy estimate or conditioned dataset flag
-		if(argv[3][1] == 'i') initial_entropy = true;
-		else if(argv[3][1] == 'c') initial_entropy = false;
-		else{
-			printf("Must specify whether computing initial entropy estimate or conditioned dataset.\n");
-			print_usage();
-			exit(-1);
-		}
-
-		// get bitstring length flag
-		if(data.word_size > 1){
-			if(argv[4][1] == 'a') all_bits = true;
-			else if(argv[4][1] == 't') all_bits = false;
-			else{
-				printf("Must specify whether or not to truncate bitstring to %d bits.\n", MIN_SIZE);
-				print_usage();
-				exit(-1);
-			}
-		}
-		else all_bits = true;
-
-		if(argc == 6) verbose = (argv[5][1] == verbose_flag);
 	}
 
 	if(verbose){
@@ -98,7 +105,6 @@ int main(int argc, char* argv[]){
 	if(!read_file(file_path, &data)){
 		printf("Error reading file.\n");
 		print_usage();
-		exit(-1);
 	}
 
 	if(data.alph_size <= 1){

--- a/cpp/iid_main.cpp
+++ b/cpp/iid_main.cpp
@@ -7,7 +7,7 @@
 #include <getopt.h>
 
 [[ noreturn ]] void print_usage(){
-	printf("Usage is: ea_iid <file_name> <bits_per_word> <-i|-c> <-a|-t> [-v]\n\n");
+	printf("Usage is: ea_iid <-i|-c> <-a|-t> [-v] <file_name> <bits_per_word>\n\n");
 	printf("\t <file_name>: Must be relative path to a binary file with at least 1 million entries (words).\n");
 	printf("\t <bits_per_word>: Must be between 1-8, inclusive.\n");
 	printf("\t <-i|-c>: '-i' for initial entropy estimate, '-c' for conditioned sequential dataset entropy estimate.\n");

--- a/cpp/non_iid_main.cpp
+++ b/cpp/non_iid_main.cpp
@@ -13,7 +13,7 @@
 
 
 [[ noreturn ]] void print_usage(){
-	printf("Usage is: ea_non_iid <file_name> <bits_per_word> <-i|-c> <-a|-t> [-v]\n\n");
+	printf("Usage is: ea_non_iid <-i|-c> <-a|-t> [-v] <file_name> <bits_per_word>\n\n");
 	printf("\t <file_name>: Must be relative path to a binary file with at least 1 million entries (words).\n");
 	printf("\t <bits_per_word>: Must be between 1-8, inclusive.\n");
 	printf("\t <-i|-c>: '-i' for initial entropy estimate, '-c' for conditioned sequential dataset entropy estimate.\n");

--- a/cpp/restart_main.cpp
+++ b/cpp/restart_main.cpp
@@ -15,7 +15,7 @@
 #define SIMULATION_ROUNDS 5000000
 
 [[ noreturn ]] void print_usage(){
-	printf("Usage is: ea_restart <file_name> <bits_per_word> <H_I> <-i|-n> [-v]\n\n");
+	printf("Usage is: ea_restart <-i|-n> [-v] <file_name> <bits_per_word> <H_I>\n\n");
 	printf("\t <file_name>: Must be relative path to a binary file with at least 1 million entries (words).\n");
 	printf("\t <bits_per_word>: Must be between 1-8, inclusive.\n");
 	printf("\t <H_I>: Initial entropy estimate.\n");

--- a/cpp/restart_main.cpp
+++ b/cpp/restart_main.cpp
@@ -9,10 +9,12 @@
 #include "non_iid/compression_test.h"
 #include "non_iid/markov_test.h"
 
+#include <getopt.h>
+
 //Each test has a targeted chance of roughly 0.000005, and we need to witness at least 5 failures, so this should be no less than 1000000
 #define SIMULATION_ROUNDS 5000000
 
-void print_usage(){
+[[ noreturn ]] void print_usage(){
 	printf("Usage is: ea_restart <file_name> <bits_per_word> <H_I> <-i|-n> [-v]\n\n");
 	printf("\t <file_name>: Must be relative path to a binary file with at least 1 million entries (words).\n");
 	printf("\t <bits_per_word>: Must be between 1-8, inclusive.\n");
@@ -38,6 +40,7 @@ void print_usage(){
 	printf("\t min(H_r, H_c, H_I), which is either the validated entropy assessment or used to derive\n");
 	printf("\t 'h_in' if conditioning is used (Section 3.1.5).\n"); 
 	printf("\n");
+	exit(-1);
 }
 
 //Here, we simulate a sort of "worst case" for this test, where there are a maximal number of symbols with maximal probability,
@@ -124,7 +127,6 @@ long int simulateBound(double alpha, int k, double H_I){
 
 int main(int argc, char* argv[]){
 	bool iid, verbose = false;
-	const char verbose_flag = 'v';
 	char *file_path;
 	int r = 1000, c = 1000;
 	int counts[256];
@@ -133,43 +135,54 @@ int main(int argc, char* argv[]){
 	double H_I, H_r, H_c, alpha, ret_min_entropy; 
 	byte *rdata, *cdata;
 	data_t data;
+	int opt;
+
+	iid = false;
+	verbose = false;
+
+        while ((opt = getopt(argc, argv, "inv")) != -1) {
+                switch(opt) {
+                        case 'i':
+                                iid = true;
+                                break;
+                        case 'n':
+                                iid = false;
+                                break;
+                        case 'v':
+                                verbose = true;
+                                break;
+                        default:
+                                print_usage();
+                                break;
+                }
+        }
+
+        argc -= optind;
+        argv += optind;
+
 
 	// Parse args
-	if(argc != 5 && argc != 6){
+	if(argc != 3){
 		printf("Incorrect usage.\n");
 		print_usage();
-		exit(-1);
 	}
 	else{
 		// get filename
-		file_path = argv[1];
+		file_path = argv[0];
 
 		// get bits per word
-		data.word_size = atoi(argv[2]);
+		data.word_size = atoi(argv[1]);
 		if(data.word_size < 1 || data.word_size > 8){
 			printf("Invalid bits per word.\n");
 			print_usage();
-			exit(-1);
 		}
 
 		// get H_I	
-		H_I = atof(argv[3]);
+		H_I = atof(argv[2]);
 		if((H_I < 0) || (H_I > data.word_size)){
 			printf("H_I must be nonnegative and at most 'bits_per_word'.\n");
 			print_usage();
-			exit(-1);
 		}
-
-		// get IID or non-IID
-		if(argv[4][1] == 'i') iid = true;
-		else if(argv[4][1] == 'n') iid = false;
-		else{
-			printf("Must specify whether data is IID or non-IID.\n");
-			print_usage();
-			exit(-1);
-		}
-
-		if(argc == 6) verbose = (argv[5][1] == verbose_flag);
 	}
 
 	if(verbose) printf("Opening file: '%s'\n", file_path);
@@ -177,7 +190,6 @@ int main(int argc, char* argv[]){
 	if(!read_file(file_path, &data)){
 		printf("Error reading file.\n");
 		print_usage();
-		exit(-1);
 	}
 
         if(data.alph_size <= 1){

--- a/cpp/shared/utils.h
+++ b/cpp/shared/utils.h
@@ -110,11 +110,11 @@ bool relEpsilonEqual(double A, double B, double maxAbsFactor, double maxRelFacto
 
    //Is absA, diff, or absB * maxRelFactor subnormal?
    //Did diff overflow?
-   //if absA is effectively 0, then relative difference is effectively examining the fractional part absB, which isn't that meaningful
+   //if absA is subnormal (effectively 0) or 0, then relative difference isn't meaningful, as fabs(B-A)/B≈1 for all values of B
    //In the instance of overflows, the resulting relative comparison will be nonsense.
    if((absA < DBL_MIN) || (diff < DBL_MIN) || std::isinf(diff) || (absB * maxRelFactor < DBL_MIN)) {
       //Yes. Relative closeness is going to be nonsense
-      return diff < maxAbsFactor;
+      return diff <= maxAbsFactor;
    } else {
       //No. Using relative closeness is probably the right thing to do.
       //Proceeding roughly as per Knuth AoCP vol II (section 4.2.2)

--- a/cpp/shared/utils.h
+++ b/cpp/shared/utils.h
@@ -128,7 +128,7 @@ bool relEpsilonEqual(double A, double B, double maxAbsFactor, double maxRelFacto
    //but perhaps that's just due to IEEE representation. Check to see if the value is within maxULP ULPs.
 
    //We can't meaningfully compare non-zero values with 0.0 in this way,
-   //but absA > DBL_MIN if we're here, so neither value is 0.0.
+   //but absA >= DBL_MIN if we're here, so neither value is 0.0.
 
    //if they aren't the same sign, then these can't be only a few ULPs away from each other
    if(signbit(A) != signbit(B)) {


### PR DESCRIPTION
This seems to be a general issue for all large data sets. This pull request converts the data storage in permutation testing to dynamic allocations, and addresses at least one problem with large data sets.

I think that this closes issue #97 , closes issue #66, closes issue #100, closes issue #101, closes issue #102.