### PR TITLE
Fixes for a few recently found scientific computing and language issues

### DIFF
--- a/cpp/iid/permutation_tests.h
+++ b/cpp/iid/permutation_tests.h
@@ -282,35 +282,42 @@ unsigned long int covariance(const byte data[], const unsigned int p, const unsi
 //
 // Can handle binary and non-binary data
 unsigned int compression(const byte data[], const int sample_size, const byte max_symbol){
-
 	// Build string of bytes
-	string msg;
-	char buffer[8];
+	char buffer[5];
+	//Reserve the necessary size sample_size*(floor(log10(max_symbol))+2)
+	//This is "worst case" and accounts for the space at the end of the number, as well.
+	char *msg = new char[(size_t)(floor(log10(max_symbol))+2.0)*sample_size];
+	unsigned int curlen = 0;
+	char *curmsg;
+	msg[0] = '\0';
+	curmsg = msg;
 
 	assert(max_symbol > 0);
 
-	//Reserve the necessary size sample_size*(floor(log10(max_symbol))+2)
-	//This is "worst case" and accounts for the space at the end of the number, as well.
-	msg.reserve((floor(log10(max_symbol))+2.0)*sample_size);
-
-	for(int i = 0; i < sample_size; ++i){
-		sprintf(buffer, "%u ", data[i]);
-		msg += buffer;
+	for(int i = 0; i < sample_size; ++i) {
+		int res;
+		res = sprintf(curmsg, "%u ", data[i]);
+		assert(res >= 2);
+		curlen += res;
+		curmsg += res;
 	}
 
 	// Remove the extra ' ' at the end
-	msg.pop_back();
+	curmsg--;
+	*curmsg = '\0';
+	assert(curlen > 0);
+	curlen--;
 
 	// Set up structures for compression
-	char* source = (char*)msg.c_str();
-	unsigned int dest_len = ceil(1.01*msg.length()) + 600;
+	unsigned int dest_len = ceil(1.01*curlen) + 600;
 	char* dest = new char[dest_len];
 
 	// Compress and capture the size of the compressed data
-	int rc = BZ2_bzBuffToBuffCompress(dest, &dest_len, source, msg.length(), 5, 0, 0);
+	int rc = BZ2_bzBuffToBuffCompress(dest, &dest_len, msg, curlen, 5, 0, 0);
 
 	// Free memory
 	delete[](dest);
+	delete[](msg);
 
 	// Return with proper return code
 	if(rc == BZ_OK){
@@ -430,8 +437,6 @@ void compression_test(const byte data[], const int sample_size, long double *sta
 void run_tests(const data_t *dp, const byte data[], const byte rawdata[], const double rawmean, const double median, long double *stats, const bool *test_status){
 
 	// Perform tests
-	//double start_time = omp_get_wtime();
-
 	excursion_test(rawdata, rawmean, dp->len, stats, test_status);
 	directional_tests(data, dp->alph_size, dp->len, stats, test_status);
 	consecutive_runs_tests(data, median, dp->alph_size, dp->len, stats, test_status);
@@ -444,8 +449,6 @@ void run_tests(const data_t *dp, const byte data[], const byte rawdata[], const 
 		covariance_tests(rawdata, dp->alph_size, dp->len, stats, test_status);
 	}
 	compression_test(rawdata, dp->len, stats, dp->maxsymbol, test_status);
-
-	//cout << endl << "Iteration time elapsed: " << omp_get_wtime() - start_time << endl;
 }
 
 /*

--- a/cpp/iid/permutation_tests.h
+++ b/cpp/iid/permutation_tests.h
@@ -282,17 +282,19 @@ unsigned long int covariance(const byte data[], const unsigned int p, const unsi
 //
 // Can handle binary and non-binary data
 unsigned int compression(const byte data[], const int sample_size, const byte max_symbol){
-	// Build string of bytes
 	char buffer[5];
-	//Reserve the necessary size sample_size*(floor(log10(max_symbol))+2)
-	//This is "worst case" and accounts for the space at the end of the number, as well.
-	char *msg = new char[(size_t)(floor(log10(max_symbol))+2.0)*sample_size];
+	char *msg;
 	unsigned int curlen = 0;
 	char *curmsg;
-	msg[0] = '\0';
-	curmsg = msg;
 
 	assert(max_symbol > 0);
+
+	// Build string of bytes
+	// Reserve the necessary size sample_size*(floor(log10(max_symbol))+2)
+	// This is "worst case" and accounts for the space at the end of the number, as well.
+	msg = new char[(size_t)(floor(log10(max_symbol))+2.0)*sample_size];
+	msg[0] = '\0';
+	curmsg = msg;
 
 	for(int i = 0; i < sample_size; ++i) {
 		int res;
@@ -302,11 +304,13 @@ unsigned int compression(const byte data[], const int sample_size, const byte ma
 		curmsg += res;
 	}
 
-	// Remove the extra ' ' at the end
-	curmsg--;
-	*curmsg = '\0';
-	assert(curlen > 0);
-	curlen--;
+	if(curlen > 0) {
+		// Remove the extra ' ' at the end
+		assert(curmsg > msg);
+		curmsg--;
+		*curmsg = '\0';
+		curlen--;
+	}
 
 	// Set up structures for compression
 	unsigned int dest_len = ceil(1.01*curlen) + 600;

--- a/cpp/non_iid/collision_test.h
+++ b/cpp/non_iid/collision_test.h
@@ -54,7 +54,7 @@ double collision_test(byte* data, long len, const int verbose, const char *label
 
 	// Directly calculate p
 	X -= ZALPHA * s/sqrt(v);
-	//p is the smallest meaninful value here.
+	//2 is the smallest meaninful value here.
 	if(X < 2.0) X = 2.0;
 
 	if(verbose == 2)

--- a/cpp/non_iid/collision_test.h
+++ b/cpp/non_iid/collision_test.h
@@ -52,104 +52,26 @@ double collision_test(byte* data, long len, const int verbose, const char *label
 		printf("%s Collision Estimate: sigma-hat = %.17g\n", label, s);
 	}
 
-	// binary search for p
+	// Directly calculate p
 	X -= ZALPHA * s/sqrt(v);
+	//p is the smallest meaninful value here.
+	if(X < 2.0) X = 2.0;
 
 	if(verbose == 2)
 		printf("%s Collision Estimate: X-bar' = %.17g\n", label, X);
 
-	if(col_exp(0.5) > X) {
-
-		ldomain = 0.5;
-		hdomain = 1.0;
-
-		lbound = ldomain;
-		hbound = hdomain;
-
-		lvalue = DBL_INFINITY;
-		hvalue = -DBL_INFINITY;
-
-		//Note that the bounds are in [0,1], so overflows aren't an issue
-		//But underflows are.
-		p = (lbound + hbound) / 2.0;
-		pVal = col_exp(p);
-
-		//We don't need the initial pVal invariant, as our initial bounds are infinite.
-		//We don't need the initial bounds, as they are set to the domain bounds
-		for(j=0; j<ITERMAX; j++) {
-			//Have we reached "equality"?
-			if(relEpsilonEqual(pVal, X, ABSEPSILON, RELEPSILON, 4)) break;
-
-			//Now update based on the found pVal
-			if(X < pVal) {
-				lbound = p;
-				lvalue = pVal;
-			} else {
-				hbound = p;
-				hvalue = pVal;
-			}
-
-			//We now verify that ldomain <= lbound < p < hbound <= hdomain
-			//and that target in [ lvalue, hvalue ]
-			if(lbound >= hbound) {
-				p = fmin(fmax(lbound, hbound),hdomain);
-				break;
-			}
-
-			//invariant. If this isn't true, then we can't evaluate here.
-			if(!(INCLOSEDINTERVAL(lbound, ldomain, hdomain) && INCLOSEDINTERVAL(hbound,  ldomain, hdomain))) {
-				//This is a search failure. We need to return "full entropy"  (as directed in step #8).
-				p = ldomain;
-				break;
-			}
-
-			//invariant. If this isn't true, then seeking the value within this interval doesn't make sense.
-			if(!INCLOSEDINTERVAL(X, lvalue, hvalue)) {
-				//This is a search failure. We need to return "full entropy"  (as directed in step #8).
-				p = ldomain;
-				break;
-			}
-
-			//Update p
-			lastP = p;
-			p = (lbound + hbound) / 2.0;
-
-			//invariant. If this isn't true, then further calculation isn't really meaningful.
-			if(!INOPENINTERVAL(p,  lbound, hbound)) {
-				p = hbound;
-				break;
-			}
-
-
-	#pragma GCC diagnostic push
-	#pragma GCC diagnostic ignored "-Wfloat-equal"
-			//Look for a cycle
-			if(lastP == p) {
-				p = hbound;
-				break;
-			}
-	#pragma GCC diagnostic pop
-
-			pVal = col_exp(p);
-
-			//invariant: If this isn't true, then this isn't loosly monotonic
-			if(!INCLOSEDINTERVAL(pVal, lvalue, hvalue)) {
-				p = hbound;
-				break;
-			}
-		}//for loop
-	} else {
-		p = -1.0;
-	}
-
-	if(p > 0.5) {
+	//Uyen Dinh observed that (with the simpler F function described in UL comments) we can simplify the entire expression much further than in 90B.
+	//The whole mess in 90B step 7 reduces to X'-bar = -2p^2 + 2p + 2, which we can solve using the quadratic formula.
+	//We only care about the root greater than 0.5, so we only care about the "+" branch.
+	//If the meanbound > 2.5, then the roots become complex, so this isn't well defined (and is processed as per the error handling specified in 90B).
+	if(X < 2.5) {
+		p = 0.5 + sqrt(1.25 - 0.5 * X);
 		entEst = -log2(p);
-
 		if(verbose == 2) printf("%s Collision Estimate: Found p.\n", label);
 	} else {
+		if(verbose == 2) printf("%s Collision Estimate: Could Not Find p. Proceeding with the lower bound for p.\n", label);
 		p = 0.5;
 		entEst = 1.0;
-		if(verbose == 2) printf("%s Collision Estimate: Could Not Find p. Proceeding with the lower bound for p.\n", label);
 	}
 
 	if(verbose == 1) printf("p = %.17g\n", p);

--- a/cpp/non_iid/lag_test.h
+++ b/cpp/non_iid/lag_test.h
@@ -1,41 +1,111 @@
 #pragma once
 #include "../shared/utils.h"
 
-#define D_LAG 128
+#define D_LAG 128U
+#define LAGMASK (D_LAG-1)
 
-// Section 6.3.8 - Lag Prediction Estimate
-double lag_test(byte *data, long len, int alph_size, const int verbose, const char *label){
-	int winner; 
-	long i, d, N, C, run_len, max_run_len;
+/*Convention:
+ * if start==end, the buffer is empty. Start and end values are not ANDed, so range from 0...255
+ * This extended range allows for use of all the entries of the buffer
+ * See https://www.snellman.net/blog/archive/2016-12-13-ring-buffers/
+ * The actual data locations range 0...127
+ * start&LAGMASK is the index of the oldest data
+ * end&LAGMASK is the index where the *next* data goes.
+ */
+
+struct lagBuf {
+	uint8_t start;
+	uint8_t end;
+	long buf[D_LAG];
+};
+
+/* Lag prediction estimate (6.3.8)
+ * This is a somewhat counter-intuitive approach to this test; the original idea for this approach is due
+ * to David Oksner. The straight forward way is simply to check j symbols back for each case (where j runs
+ * 1 to 128). It ends up that this is bizarrely slow.
+ * This approach is to keep a list of offsets where we encountered each symbol (in a ring buffer,
+ * which can store at most D (128) prior elements.
+ * For this, one needs only check and update the current symbol's ring buffer, and we only need to spend
+ * time looking at values that correspond to counters that must be updated.
+ */
+double lag_test(byte *S, long L, int k, const int verbose, const char *label) {
 	long scoreboard[D_LAG] = {0};
-	
-	if(len < 2){	
-		printf("\t*** Warning: not enough samples to run lag test (need more than %d) ***\n", 2);
-		return -1.0;
+	int winner = 0;
+	long curRunOfCorrects = 0;
+	long maxRunOfCorrects = 0;
+	long correctCount = 0;
+	lagBuf *ringBuffers;
+	long highScore = 0;
+
+	assert(S != NULL);
+	assert(L > 2);
+	assert(k >= 2);
+
+	ringBuffers = new lagBuf[k];
+
+	//Flag all the rings as empty
+	for (int j = 0; j < k; j++) {
+		ringBuffers[j].start = 0;
+		ringBuffers[j].end = 0;
 	}
 
-	N = len-1;
-	winner = 0;
-	C = 0;
-	run_len = 0;
-	max_run_len = 0;
+	// Account for the very first symbol (there isn't a guess for this one)
+	ringBuffers[S[0]].buf[0] = 0;
+	ringBuffers[S[0]].start = 0;
+	ringBuffers[S[0]].end = 1;
 
-	// perform predictions
-	for (i = 1; i < len; i++){
-		// test prediction of winner
-		if(data[i-winner-1] == data[i]){
-			C++;
-			if(++run_len > max_run_len) max_run_len = run_len;
-		}
-		else run_len = 0;
+	// The rest of the values yield a prediction
+	for (long i = 1; i < L; i++) {
+		const byte curSymbol = S[i];
+		lagBuf *const curRingBuffer = &(ringBuffers[curSymbol]); // The pointer itself is a constant (not the structure it points to)
 
-		// update scoreboard and select new winner
-		for(d = 0; d < D_LAG; d++){
-			if((i > d) && (data[i-d-1] == data[i])){
-				if(++scoreboard[d] >= scoreboard[winner]) winner = d;
+		// Check the prediction first
+		if (curSymbol == S[i - winner - 1]) {
+			correctCount++;
+			curRunOfCorrects++;
+			if (curRunOfCorrects > maxRunOfCorrects) {
+				maxRunOfCorrects = curRunOfCorrects;
 			}
+		} else {
+			curRunOfCorrects = 0;
 		}
+
+		// Update counters
+		if (curRingBuffer->start != curRingBuffer->end) {
+			uint8_t counterIndex = curRingBuffer->end;
+			const long cutoff = (i >= D_LAG) ? (i - D_LAG) : 0;  // Cutoff is the oldest stream index that should be present in the buffer
+
+			do {
+				counterIndex--;
+				if (curRingBuffer->buf[counterIndex&LAGMASK] >= cutoff) {
+					long curScore;
+					long curOffset;
+					curOffset = i - curRingBuffer->buf[counterIndex&LAGMASK] - 1;
+					assert(curOffset < D_LAG);
+					curScore = ++scoreboard[curOffset];
+
+					if (curScore >= highScore) {
+						winner = curOffset;
+						highScore = curScore;
+					}
+				} else {
+					// The correct start was the prior symbol (which is the next symbol in the buffer)
+					curRingBuffer->start = (uint8_t)(counterIndex + 1U);
+					break;
+				}
+			} while (counterIndex != curRingBuffer->start);
+		}
+
+		// Add the new symbol
+		// Are we already full? If so, advance the start index.
+		if((uint8_t)(curRingBuffer->end - curRingBuffer->start) == D_LAG) curRingBuffer->start++;
+		//Add the current offset and adjust the end index
+		curRingBuffer->buf[(curRingBuffer->end)&LAGMASK] = i;
+		curRingBuffer->end++;
+		assert((uint8_t)(curRingBuffer->end - curRingBuffer->start) <= D_LAG);
 	}
 
-	return(predictionEstimate(C, N, max_run_len, alph_size, "Lag", verbose, label));
+	delete[] ringBuffers;
+
+	return predictionEstimate(correctCount, L-1, maxRunOfCorrects, k, "Lag", verbose, label);
 }

--- a/cpp/non_iid/markov_test.h
+++ b/cpp/non_iid/markov_test.h
@@ -11,6 +11,8 @@ double markov_test(byte* data, long len, const int verbose, const char *label){
 	C_00 = 0;
 	C_10 = 0;
 
+	assert(len > 0);
+
 	// get counts for unconditional and transition probabilities
 	for(i = 0; i < len-1; i++){
 		if(data[i] == 0){
@@ -22,17 +24,24 @@ double markov_test(byte* data, long len, const int verbose, const char *label){
 
 	//C_0 is now  the number of 0 bits from S[0] to S[len-2]
 	
-	//We can't get meaningful results if all but the last bit is the same.
-	if((C_0 == 0) || (C_0 == len - 1)) return 0.0;
-
 	C_1 = len - 1 - C_0; //C_1 is the number of 1 bits from S[0] to S[len-2]
 
-	P_00 = ((double)C_00) / ((double)C_0);
-	P_10 = ((double)C_10) / ((double)C_1);
-
 	//Note that P_X1 = C_X1 / C_X = (C_X - C_X0)/C_X = 1.0 - C_X0/C_X = 1.0 - P_X0 
-	P_01 = 1.0 - P_00;
-	P_11 = 1.0 - P_10;
+	if(C_0 > 0) {
+		P_00 = ((double)C_00) / ((double)C_0);
+		P_01 = 1.0 - P_00;
+	} else {
+		P_00 = 0.0;
+		P_01 = 0.0;
+	}
+
+	if(C_1 > 0) {
+		P_10 = ((double)C_10) / ((double)C_1);
+		P_11 = 1.0 - P_10;
+	} else {
+		P_10 = 0.0;
+		P_11 = 0.0;
+	}
 
 	// account for the last symbol
 	if(data[len-1] == 0) C_0++;

--- a/cpp/non_iid/markov_test.h
+++ b/cpp/non_iid/markov_test.h
@@ -4,7 +4,7 @@
 // Section 6.3.3 - Markov Estimate
 // data is assumed to be binary (e.g., bit string)
 double markov_test(byte* data, long len, const int verbose, const char *label){
-	long i, C_0, C_1, C_00, C_01, C_10, C_11;
+	long i, C_0, C_1, C_00, C_10;
 	double H_min, tmp_min_entropy, P_0, P_1, P_00, P_01, P_10, P_11, entEst;
 
 	C_0 = 0;
@@ -26,8 +26,6 @@ double markov_test(byte* data, long len, const int verbose, const char *label){
 	if((C_0 == 0) || (C_0 == len - 1)) return 0.0;
 
 	C_1 = len - 1 - C_0; //C_1 is the number of 1 bits from S[0] to S[len-2]
-	C_01 = C_0 - C_00;
-	C_11 = C_1 - C_10;
 
 	P_00 = ((double)C_00) / ((double)C_0);
 	P_10 = ((double)C_10) / ((double)C_1);

--- a/cpp/non_iid/markov_test.h
+++ b/cpp/non_iid/markov_test.h
@@ -11,7 +11,8 @@ double markov_test(byte* data, long len, const int verbose, const char *label){
 	C_00 = 0;
 	C_10 = 0;
 
-	assert(len > 0);
+	//Less than 2 symbols don't make sense for a Markov model.
+	assert(len > 1);
 
 	// get counts for unconditional and transition probabilities
 	for(i = 0; i < len-1; i++){

--- a/cpp/shared/most_common.h
+++ b/cpp/shared/most_common.h
@@ -9,6 +9,8 @@ double most_common(byte* data, const long len, const int alph_size, const int ve
 	double pmax, ubound;
 	double entEst;
 
+	assert(len > 1);
+
 	for(i = 0; i < alph_size; i++) counts[i] = 0;
 	for (i = 0; i < len; i++) counts[data[i]]++;
 

--- a/cpp/shared/utils.h
+++ b/cpp/shared/utils.h
@@ -797,6 +797,7 @@ double prediction_estimate_function(long double p, long r, long N){
 		x = 1.0L + q*powl(p, r)*powl(x, r+1.0L);
 		//We expect this convergence to be monotonic up.
 		assert(x >= xlast);
+		//We expect x<=1/p
 		assert(p*x <= 1.0L);
 	}
 

--- a/cpp/shared/utils.h
+++ b/cpp/shared/utils.h
@@ -781,11 +781,25 @@ double divide(const int a, const int b) {
 }
 
 double prediction_estimate_function(long double p, long r, long N){
-	long double q, x;
+	long double q, x, xlast=0.0L;
+	assert(p > 0.0L); //In fact, it is >= 1/k
+	assert(p <= 1.0L);
 
 	q = 1.0L-p;
 	x = 1.0L;
-	for(int i = 0; i < 10; i++) x = 1.0L + q*powl(p, r)*powl(x, r+1.0L);
+
+	//We know that 
+	// * x is in the interval [1,1/p] which is a subset of [1,k]
+	// * the sequence is monotonic up (so x >= xlast).
+	//As such we don't need much fancyness for looking for "equality"
+	for(int i = 0; (i <= 65) && ((x - xlast) > (LDBL_EPSILON*x)); i++) {
+		xlast = x;
+		x = 1.0L + q*powl(p, r)*powl(x, r+1.0L);
+		//We expect this convergence to be monotonic up.
+		assert(x >= xlast);
+		assert(p*x <= 1.0L);
+	}
+
 	return((double)(logl(1.0L-p*x) - logl((r+1.0L-r*x)*q) - (N+1.0L)*logl(x)));
 }
 

--- a/cpp/shared/utils.h
+++ b/cpp/shared/utils.h
@@ -783,7 +783,7 @@ double divide(const int a, const int b) {
 double prediction_estimate_function(long double p, long r, long N){
 	long double q, x, xlast=0.0L;
 	assert(p > 0.0L); //In fact, it is >= 1/k
-	assert(p <= 1.0L);
+	assert(p < 1.0L);
 
 	q = 1.0L-p;
 	x = 1.0L;


### PR DESCRIPTION
We've been doing some detailed 90B training, and in the process we have found a few issues in the 90B implementation and specification.  This pull request provides a fix for the iid compression permutation test, a fix for all of the predictor tests (having to do with the calculation of P_local), a significant refinement of the collision estimator, and a different approach to performing the lag test (which is twice as fast as the prior approach).

We've tested these changes (using clang's AddressSanitizer and static analyzer, an internal test suite, and the built-in test suite). We welcome any comments or proposed changes.

Resolves usnistgov/SP800-90B_EntropyAssessment#131.
Resolves usnistgov/SP800-90B_EntropyAssessment#132 (see UL SP800-90B comment 19)
Resolves usnistgov/SP800-90B_EntropyAssessment#133 (see UL SP800-90B comment 24b)
Resolves usnistgov/SP800-90B_EntropyAssessment#141.

You can get the UL comments [here](http://bit.ly/UL90BCOM).