### PR TITLE
Make ea_conditioning use arbitrary precision arithmetic (and only that)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# EntropyAssessment
+	# EntropyAssessment
 
 Cryptographic random bit generators (RBGs), also known as random number generators (RNGs), require a noise source that produces digital outputs with some level of unpredictability, expressed as min-entropy. [SP 800-90B](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-90B.pdf) provides a standardized means of estimating the quality of a source of entropy.
 
@@ -73,6 +73,8 @@ Running this is similar.
 	
 	./ea_restart [-i|-n] [-v] <file_name> [bits_per_symbol] <H_I>
 
+The file should be in the "row dataset" format described in SP800-90B Section 3.1.4.1.
+
 * `-i`: Indicates IID data.
 * `-n`: Indicates non-IID data.
 * `-v`: Optional verbosity flag for more output. Can be used multiple times.
@@ -91,11 +93,13 @@ or
 
     ea_conditioning -n <n_in> <n_out> <nw> <h_in> <h'>
 
-* `-v`: Optional verbosity flag for more output. Can be used multiple times.
-* `n_in`: The number of bits entering the conditioning step per output.
-* `n_out`: The number of bits per conditioning step output.
-* `nw`: The narrowest width of the conditioning step.
-* `h_in`: The amount of entropy entering the conditioning step per output. Must be less than n_in.
+ * `-v`: The conditioning function is vetted.
+ * `-n`: The conditioning function is non-vetted.
+ * `n_in`: The number of bits entering the conditioning step per output.
+ * `n_out`: The number of bits per conditioning step output.
+ * `nw`: The narrowest width of the conditioning step.
+ * `h_in`: The amount of entropy entering the conditioning step per output. Must be less than n_in.
+ * `h'`:  The entropy estimate per bit of conditioned sequential dataset (only for '-n' option).
 
 ## Make
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-	# EntropyAssessment
+# EntropyAssessment
 
 Cryptographic random bit generators (RBGs), also known as random number generators (RNGs), require a noise source that produces digital outputs with some level of unpredictability, expressed as min-entropy. [SP 800-90B](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-90B.pdf) provides a standardized means of estimating the quality of a source of entropy.
 
@@ -93,13 +93,13 @@ or
 
     ea_conditioning -n <n_in> <n_out> <nw> <h_in> <h'>
 
- * `-v`: The conditioning function is vetted.
- * `-n`: The conditioning function is non-vetted.
- * `n_in`: The number of bits entering the conditioning step per output.
- * `n_out`: The number of bits per conditioning step output.
- * `nw`: The narrowest width of the conditioning step.
- * `h_in`: The amount of entropy entering the conditioning step per output. Must be less than n_in.
- * `h'`:  The entropy estimate per bit of conditioned sequential dataset (only for '-n' option).
+* `-v`: The conditioning function is vetted.
+* `-n`: The conditioning function is non-vetted.
+* `n_in`: The number of bits entering the conditioning step per output.
+* `n_out`: The number of bits per conditioning step output.
+* `nw`: The narrowest width of the conditioning step.
+* `h_in`: The amount of entropy entering the conditioning step per output. Must be less than n_in.
+* `h'`:  The entropy estimate per bit of conditioned sequential dataset (only for '-n' option).
 
 ## Make
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Issues on this repository are strictly for problems or questions concerning the 
 
 This code package requires a C++11 compiler. The code uses OpenMP directives, so compiler support for OpenMP is expected. GCC is preferred (and the only platform tested). There is one method that involves a GCC built-in function (`chi_square_tests.h -> binary_goodness_of_fit() -> __builtin_popcount()`). To run this you will need some compiler that supplies this GCC built-in function (GCC and clang both do so).
 
-The resulting binary is linked with bzlib and divsufsort, so these libraries (and their associated include files) must be installed and accessible to the compiler.
+The resulting binary is linked with bzlib, divsufsort, GMP MP and GNU MPFR, so these libraries (and their associated include files) must be installed and accessible to the compiler.
 
 See [the wiki](https://github.com/usnistgov/SP800-90B_EntropyAssessment/wiki/Installing-libdivsufsort) for some distribution-specific instructions on installing divsufsort.
 
@@ -55,6 +55,7 @@ You may specify either `-i` or `-c`, and either `-a` or `-t`. These correspond t
 * Note: When testing binary data, no `H_bitstring` assessment is produced, so the `-a` and `-t` options produce the same results for the initial assessment of binary data.
 * `-l`: Reads (at most) `samples` data samples after indexing into the file by `index*samples` bytes.
 * `-v`: Optional verbosity flag for more output. Can be used multiple times.
+=======
 * bits_per_symbol are the number of bits per symbol. Each symbol is expected to fit within a single byte.
 
 To run the non-IID tests, use the Makefile to compile:

--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ You may specify either `-i` or `-c`, and either `-a` or `-t`. These correspond t
 * Note: When testing binary data, no `H_bitstring` assessment is produced, so the `-a` and `-t` options produce the same results for the initial assessment of binary data.
 * `-l`: Reads (at most) `samples` data samples after indexing into the file by `index*samples` bytes.
 * `-v`: Optional verbosity flag for more output. Can be used multiple times.
-=======
 * bits_per_symbol are the number of bits per symbol. Each symbol is expected to fit within a single byte.
 
 To run the non-IID tests, use the Makefile to compile:
@@ -73,8 +72,6 @@ To run the restart testing, use the Makefile to compile:
 Running this is similar.
 	
 	./ea_restart [-i|-n] [-v] <file_name> [bits_per_symbol] <H_I>
-
-The file should be in the "row dataset" format described in SP800-90B Section 3.1.4.1.
 
 * `-i`: Indicates IID data.
 * `-n`: Indicates non-IID data.
@@ -94,13 +91,11 @@ or
 
     ea_conditioning -n <n_in> <n_out> <nw> <h_in> <h'>
 
-* `-v`: The conditioning function is vetted.
-* `-n`: The conditioning function is non-vetted.
+* `-v`: Optional verbosity flag for more output. Can be used multiple times.
 * `n_in`: The number of bits entering the conditioning step per output.
 * `n_out`: The number of bits per conditioning step output.
 * `nw`: The narrowest width of the conditioning step.
 * `h_in`: The amount of entropy entering the conditioning step per output. Must be less than n_in.
-* `h'`:  The entropy estimate per bit of conditioned sequential dataset (only for '-n' option).
 
 ## Make
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This code package requires a C++11 compiler. The code uses OpenMP directives, so
 
 The resulting binary is linked with bzlib, divsufsort, GMP MP and GNU MPFR, so these libraries (and their associated include files) must be installed and accessible to the compiler.
 
-See [the wiki](https://github.com/usnistgov/SP800-90B_EntropyAssessment/wiki/Installing-libdivsufsort-and-bzlib) for some distribution-specific instructions on installing divsufsort.
+See [the wiki](https://github.com/usnistgov/SP800-90B_EntropyAssessment/wiki/Installing-Packages) for some distribution-specific instructions on installing the mentioned packages.
 
 ## Overview
 

--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -30,7 +30,7 @@ restart_main.o: restart_main.cpp
 
 conditioning: conditioning_main.o
 conditioning_main.o: conditioning_main.cpp
-	$(CXX) $(CXXFLAGS) $(INC) conditioning_main.cpp -o ea_conditioning $(LIB)
+	$(CXX) $(CXXFLAGS) $(INC) conditioning_main.cpp -o ea_conditioning $(LIB) -lmpfr -lgmp
 
 transpose: transpose_main.o
 transpose_main.o: transpose_main.cpp

--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -30,7 +30,7 @@ restart_main.o: restart_main.cpp
 
 conditioning: conditioning_main.o
 conditioning_main.o: conditioning_main.cpp
-	$(CXX) $(CXXFLAGS) $(INC) conditioning_main.cpp -o ea_conditioning $(LIB) -lmpfr -lgmp
+	$(CXX) $(CXXFLAGS) $(INC) conditioning_main.cpp -o ea_conditioning -lmpfr -lgmp
 
 transpose: transpose_main.o
 transpose_main.o: transpose_main.cpp

--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -5,6 +5,7 @@ CXXFLAGS = -std=c++11 -fopenmp -O2 -msse2 -ffloat-store -march=native
 #static analysis in clang using
 #scan-build-8 --use-c++=/usr/bin/clang++-8 make
 LIB = -lbz2 -lpthread -ldivsufsort
+COND_LIB = -lmpfr -lgmp
 INC=
 
 ######
@@ -30,7 +31,7 @@ restart_main.o: restart_main.cpp
 
 conditioning: conditioning_main.o
 conditioning_main.o: conditioning_main.cpp
-	$(CXX) $(CXXFLAGS) $(INC) conditioning_main.cpp -o ea_conditioning -lmpfr -lgmp
+	$(CXX) $(CXXFLAGS) $(INC) conditioning_main.cpp -o ea_conditioning $(COND_LIB)
 
 transpose: transpose_main.o
 transpose_main.o: transpose_main.cpp

--- a/cpp/conditioning_main.cpp
+++ b/cpp/conditioning_main.cpp
@@ -140,9 +140,9 @@ int main(int argc, char* argv[]) {
 	int opt;
 	bool adaquatePrecision = false;
 	unsigned int maxval;
-	long double epsilonExp = -1.0L;
-	long double deltaExp = -1.0L;
-	long double gammaExp = -1.0L;
+	long double noutEpsilonExp = -1.0L;
+	long double hinEpsilonExp = -1.0L;
+	long double nwEpsilonExp = -1.0L;
 
 	mpfr_t ap_h_in, ap_entexp, ap_p_high, ap_p_low, ap_denom, ap_power_term, ap_psi, ap_omega, ap_outputEntropy, ap_nw, ap_n_out;
 
@@ -303,13 +303,13 @@ int main(int argc, char* argv[]) {
 			//To be conservative, round so that -log2(epsilon) epsilon is as small as possible
 			//(that is epsilon should be as large as possible)
 			mpfr_set_ui(ap_n_out, n_out, MPFR_RNDZ);
-			epsilonExp = calculateEpsilon(ap_outputEntropy, ap_n_out, precision);
+			noutEpsilonExp = calculateEpsilon(ap_outputEntropy, ap_n_out, precision);
 
 			//We may also be interested in other ways that this output may have been limited.
-			deltaExp = calculateEpsilon(ap_outputEntropy, ap_h_in, precision);
+			hinEpsilonExp = calculateEpsilon(ap_outputEntropy, ap_h_in, precision);
 
 			mpfr_set_ui(ap_nw, nw, MPFR_RNDZ);
-			gammaExp = calculateEpsilon(ap_outputEntropy, ap_nw, precision);
+			nwEpsilonExp = calculateEpsilon(ap_outputEntropy, ap_nw, precision);
 
 			//If we get here, then adequate precision was used
 			//Extract a value for display.
@@ -347,15 +347,15 @@ int main(int argc, char* argv[]) {
 	printf("Output_Entropy(*) = %.22Lg", outputEntropy);
 	if(outputEntropy == (long double)n_out) {
 		//outputEntropy rounded to full entropy, so the difference between this and full entropy is less than 1/2 ULP.
-		printf("; Close to n_out (epsilon = %.22Lg)", epsilonExp);
+		printf("; Close to n_out (epsilon = 2^(-%.22Lg))", noutEpsilonExp);
 	}
 	if(outputEntropy == h_in) {
 		//outputEntropy rounded to the input entropy, so the difference between this and the input entropy is less than 1/2 ULP.
-		printf("; Close to h_in (epsilon = %.22Lg)", deltaExp);
+		printf("; Close to h_in (epsilon = 2^(-%.22Lg))", hinEpsilonExp);
 	}
 	if(outputEntropy == (long double)nw) {
 		//outputEntropy rounded to the nw, so the difference between this and nw is less than 1/2 ULP.
-		printf("; Close to nw (epsilon = %.22Lg)", gammaExp);
+		printf("; Close to nw (epsilon = 2^(-%.22Lg))", nwEpsilonExp);
 	}
 	printf("\n");
 
@@ -364,12 +364,12 @@ int main(int argc, char* argv[]) {
 
 		if(outputEntropy > 0.999L*((long double)n_out)) {
 			//h_out = (1 - epsilon) * n_out
-			printf("epsilon = 2^(-%.22Lg)", epsilonExp);
+			printf("epsilon = 2^(-%.22Lg)", noutEpsilonExp);
 			//Should this qualify as "full entropy" under the 2012 draft of SP 800-90B?
 			//Should this qualify as "full entropy" under the 2021 SP 800-90C draft?
-			if(epsilonExp >= 64.0L) {
+			if(noutEpsilonExp >= 64.0L) {
 				printf(": SP 800-90B 2012 Draft and SP 800-90C 2021 Draft Full Entropy");
-			} else if(epsilonExp >= 32.0L) {
+			} else if(noutEpsilonExp >= 32.0L) {
 				printf(": SP 800-90C 2021 Full Entropy");
 			}
 			printf("\n");

--- a/cpp/conditioning_main.cpp
+++ b/cpp/conditioning_main.cpp
@@ -168,7 +168,9 @@ int main(int argc, char* argv[]) {
 
 	// Establish the maximum precision that ought to be necessary
 	// If something goes wrong, we can increase this precision automatically.
-	maxval = (n_in>n_out)?n_in:n_out;
+	maxval = 64; // Always be large enough to faithfully represent h_in.
+	maxval = (maxval>n_in)?maxval:n_in;
+	maxval = (maxval>n_out)?maxval:n_out;
 	maxval = (maxval>nw)?maxval:nw;
 	precision = 2*maxval;
 

--- a/cpp/conditioning_main.cpp
+++ b/cpp/conditioning_main.cpp
@@ -8,8 +8,6 @@
 #include <assert.h>
 #include <getopt.h>
 #include <mpfr.h>
-#include <stdint.h>
-#include <cinttypes>
 #include <errno.h>
 #include <fenv.h>
 

--- a/cpp/conditioning_main.cpp
+++ b/cpp/conditioning_main.cpp
@@ -198,11 +198,11 @@ int main(int argc, char* argv[]) {
 	n = std::min(n_out, nw);
 
 	//Print out the inputs
-	printf("n_in: %u\n", n_in);
-	printf("n_out: %u\n", n_out);
-	printf("nw: %u\n", nw);
-	printf("h_in: %.22Lg\n", h_in);
-	if(!vetted) printf("h': %.22Lg\n", h_p);
+	printf("n_in = %u\n", n_in);
+	printf("n_out = %u\n", n_out);
+	printf("nw = %u\n", nw);
+	printf("h_in = %.22Lg\n", h_in);
+	if(!vetted) printf("h' = %.22Lg\n", h_p);
 
 	// Establish the maximum precision that ought to be necessary
 	// If something goes wrong, we can increase this precision automatically.
@@ -223,7 +223,6 @@ int main(int argc, char* argv[]) {
 		//Initialize arbitrary precision versions of h_in
 		//We want to make sure not to lose precision here.
 		if(mpfr_set_ld(ap_h_in, h_in, MPFR_RNDZ) != 0) {
-			fprintf(stderr, "h_in not captured correctly\n");
 			adaquatePrecision=false;
 		}
 
@@ -239,7 +238,6 @@ int main(int argc, char* argv[]) {
 
 		//This is an integer value, and should be exact
 		if(mpfr_ui_pow_ui (ap_denom, 2UL, n_in, MPFR_RNDZ)!=0) {
-			fprintf(stderr, "denom term not captured correctly\n");
 			adaquatePrecision=false;
 		}
 
@@ -249,7 +247,6 @@ int main(int argc, char* argv[]) {
 		//Prior to moving on, calculate a reused power term
 		//This is an integer value, and should be exact
 		if(mpfr_ui_pow_ui(ap_power_term, 2UL, n_in - n, MPFR_RNDU)!=0) {
-			fprintf(stderr, "power term not captured correctly\n");
 			adaquatePrecision=false;
 		}
 
@@ -258,13 +255,11 @@ int main(int argc, char* argv[]) {
 		mpfr_add(ap_psi, ap_psi, ap_p_high,  MPFR_RNDU);
 		// h_in > 0 so Psi > P_high. If this isn't so, then we're doing the calculation at too low of a precision.
 		if(mpfr_cmp(ap_p_high, ap_psi) >= 0) {
-			fprintf(stderr, "P_high >= Psi\n");
 			adaquatePrecision=false;
 		}
 
 		//We're going to need an arbitrary precision version of log(2)
 		if(mpfr_set_ui(ap_omega, 2U, MPFR_RNDZ) != 0) {
-			fprintf(stderr, "2 can't be set?\n");
 			adaquatePrecision=false;
 		}
 		mpfr_log(ap_omega, ap_omega, MPFR_RNDU);
@@ -294,13 +289,11 @@ int main(int argc, char* argv[]) {
 		//Could outputEntropy be valid?
 		//We know that n_out > ap_outputEntropy for all finite inputs...
 		if(mpfr_cmp_ui(ap_outputEntropy, n_out) >= 0) {
-			fprintf(stderr, "outputEntropy >= n_out\n");
 			adaquatePrecision = false;
 		}
 
 		//We know that h_in > ap_outputEntropy for all finite inputs...
 		if(mpfr_cmp(ap_outputEntropy, ap_h_in) >= 0) {
-			fprintf(stderr, "outputEntropy >= h_in\n");
 			adaquatePrecision = false;
 		}
 
@@ -367,18 +360,19 @@ int main(int argc, char* argv[]) {
 	printf("\n");
 
 	if(vetted) {
-		printf("(Vetted) h_out: %.22Lg\n", outputEntropy);
+		printf("(Vetted) h_out = %.22Lg\n", outputEntropy);
 
 		if(outputEntropy > 0.999L*((long double)n_out)) {
 			//h_out = (1 - epsilon) * n_out
-			printf("epsilon: 2^(-%.22Lg)", epsilonExp);
+			printf("epsilon = 2^(-%.22Lg)", epsilonExp);
 			//Should this qualify as "full entropy" under the 2012 draft of SP 800-90B?
 			//Should this qualify as "full entropy" under the 2021 SP 800-90C draft?
 			if(epsilonExp >= 64.0L) {
-				printf(": SP 800-90B 2012 Draft and SP 800-90C 2021 Draft Full Entopy\n");
+				printf(": SP 800-90B 2012 Draft and SP 800-90C 2021 Draft Full Entropy");
 			} else if(epsilonExp >= 32.0L) {
-				printf(": SP 800-90C 2021 Full Entopy\n");
+				printf(": SP 800-90C 2021 Full Entropy");
 			}
+			printf("\n");
 		}
 	} else {
 		long double bound90B = 0.999L*((long double)n_out);
@@ -388,7 +382,7 @@ int main(int argc, char* argv[]) {
 		printf("0.999 * n_out = %.22Lg\n", bound90B);
 		printf("h' * n_out = %.22Lg\n", statBound);
 		h_out = std::min(outputEntropy, std::min(bound90B, statBound));
-		printf("(Non-vetted) h_out: %.22Lg\n", h_out);
+		printf("(Non-vetted) h_out = %.22Lg\n", h_out);
 	}
 
 	return 0;

--- a/cpp/conditioning_main.cpp
+++ b/cpp/conditioning_main.cpp
@@ -110,8 +110,6 @@ static long double calculateEpsilon(mpfr_t calcValue, mpfr_t maxValue,  mpfr_pre
 	mpfr_set_ui(ap_log2, 2U, MPFR_RNDZ);
 	mpfr_log(ap_log2, ap_log2, MPFR_RNDU);
 
-	mpfr_log_ui(ap_log2, 2UL, MPFR_RNDU);
-
 	//Calculate the ratio value/max
 	mpfr_set(ratio, calcValue, MPFR_RNDU);
 	mpfr_neg(ratio, ratio, MPFR_RNDD);

--- a/cpp/conditioning_main.cpp
+++ b/cpp/conditioning_main.cpp
@@ -2,12 +2,15 @@
 #include <cstdlib>
 #include <limits>
 #include <cmath>
+#include <math.h>
 #include <algorithm>
-
+#include <assert.h>
 #include <getopt.h>
 #include <mpfr.h>
+#include <errno.h>
+#include <fenv.h>
 
-[[ noreturn ]] void print_usage() {
+[[ noreturn ]] static void print_usage() {
 	printf("Usage is: ea_conditioning [-v] <n_in> <n_out> <nw> <h_in>\n");
 	printf("\tor \n\tea_conditioning -n <n_in> <n_out> <nw> <h_in> <h'>\n\n");
 	printf("\t <n_in>: input number of bits to conditioning function.\n");
@@ -27,11 +30,76 @@
 	exit(-1);
 }
 
+static long double inputLongDoubleOption(const char *input, long double low, long double high, const char *label) {
+	char *nextoptchar;
+	long double indouble;
+
+	assert(input != NULL);
+	assert(!isnan(low));
+	assert(!isnan(high));
+
+	if(label == NULL) label="parameter";
+
+	indouble = strtold(input, &nextoptchar);
+	assert(nextoptchar != NULL);
+
+	if((nextoptchar == input) || (*nextoptchar != '\0')) {
+		printf("Non-numeric characters in %s: '%c'\n", label, *nextoptchar);
+		print_usage();
+	}
+
+	if((errno == ERANGE) || !isfinite(indouble)) {
+		printf("Provided value for %s is out of range of a long double or isn't a finite value\n", label);
+		print_usage();
+	}
+
+	if(indouble < low) {
+		printf("%s must be greater than or equal to %.22Lg.\n", label, low);
+		print_usage();
+	}
+
+	if(indouble > high) {
+		printf("%s must be less than or equal to %.22Lg.\n", label, high);
+		print_usage();
+	}
+
+	return indouble;
+}
+
+static unsigned int inputUnsignedOption(const char *input, unsigned int low, unsigned int high, const char *label) {
+	char *nextoptchar;
+	unsigned long inint;
+
+	assert(input != NULL);
+
+	if(label == NULL) label="parameter";
+
+	inint = strtoul(input, &nextoptchar, 0);
+	assert(nextoptchar != NULL);
+
+	if((nextoptchar == input) || (*nextoptchar != '\0')) {
+		printf("Non-integer characters in %s: '%c'\n", label, *nextoptchar);
+		print_usage();
+	}
+
+	if(inint < (unsigned long int)low) {
+		printf("%s must be greater than or equal to %u.\n", label, low);
+		print_usage();
+	}
+
+	if(inint > (unsigned long int)high) {
+		printf("%s must be less than or equal to %u.\n", label, high);
+		print_usage();
+	}
+
+	return (unsigned int)inint;
+}
+
 int main(int argc, char* argv[]) {
 	bool vetted;
-	long double h_p = -1.0;
+	long double h_p = -1.0L;
 	long double h_in, h_out; 
-	long double outputEntropy;
+	long double outputEntropy = -1.0L;
 	unsigned int n_in, n_out, nw, n;
 	mpfr_prec_t precision;
 	int opt;
@@ -39,10 +107,14 @@ int main(int argc, char* argv[]) {
 	bool closeToFullEntropy = false;
 	bool fullEntropy = false;
 	unsigned int maxval;
-	long double epsilonExp = -1.0;
+	long double epsilonExp = -1.0L;
+
 	mpfr_t ap_h_in, ap_p_high, ap_p_low, ap_denom, ap_power_term, ap_psi, ap_omega, ap_outputEntropy, ap_log2epsilon;
 
 	vetted = true;
+
+	//Setting this rounding method helps prevent us from overestimating the input parameters
+	fesetround(FE_TOWARDZERO);
 
         while ((opt = getopt(argc, argv, "vn")) != -1) {
                 switch(opt) {
@@ -64,34 +136,21 @@ int main(int argc, char* argv[]) {
 	if((vetted && (argc != 4)) || (!vetted && (argc != 5))){
 		printf("Incorrect usage.\n");
 		print_usage();
-	}
-	else{
+	} else{
                 // get n_in     
-                n_in = strtoul(argv[0], NULL, 0);
-		if(n_in < 1) {
-                        printf("n_in must be greater than 0.\n");
-                        print_usage();
-		}
+		n_in = inputUnsignedOption(argv[0], 1, UINT_MAX, "n_in");
 
 	    	// get n_out     
-                n_out = strtoul(argv[1], NULL, 0);
+                n_out = inputUnsignedOption(argv[1], 1, UINT_MAX, "n_out");
 
-                // get n_out     
-                nw = strtoul(argv[2], NULL, 0);
+                // get nw     
+                nw = inputUnsignedOption(argv[2], 1, UINT_MAX, "nw");
 
                 // get h_in     
-                h_in = strtold(argv[3], NULL);
-                if((h_in <= 0) || (h_in > (long double)n_in)){
-                        printf("h_in must be positive and at most n_in.\n");
-                        print_usage();
-                }
+		h_in = inputLongDoubleOption(argv[3], 0.0L, (long double) n_in, "h_in");
 
 		if(!vetted){
-			h_p = strtold(argv[4], NULL);
-			if((h_p <= 0) || (h_p > 1.0)){
-				printf("h' must be the interval (0 and 1].\n");
-				print_usage();
-			}
+			h_p = inputLongDoubleOption(argv[4], 0.0L, 1.0L, "h_p");
 		} 
 	}
 
@@ -120,55 +179,57 @@ int main(int argc, char* argv[]) {
 
 	while(!adaquatePrecision) {
 		adaquatePrecision = true;
-		//Initialize arbitrary precision versions of h_in and needed constants.
-		mpfr_set_ld(ap_h_in, h_in, MPFR_RNDN);
+		//Initialize arbitrary precision versions of h_in
+		mpfr_set_ld(ap_h_in, h_in, MPFR_RNDZ);
 
 		// compute Output Entropy (Section 3.1.5.1.2)
 		// Step 1.
 		// P_high
-		mpfr_neg(ap_h_in, ap_h_in, MPFR_RNDN);
-		mpfr_ui_pow(ap_p_high, 2UL, ap_h_in, MPFR_RNDN);
+		mpfr_neg(ap_h_in, ap_h_in, MPFR_RNDZ);
+		mpfr_ui_pow(ap_p_high, 2UL, ap_h_in, MPFR_RNDZ);
 
 		//P_low
-		mpfr_ui_sub(ap_p_low, 1UL, ap_p_high, MPFR_RNDN);
-		mpfr_ui_pow_ui (ap_denom, 2UL, n_in, MPFR_RNDN);
-		mpfr_sub_ui(ap_denom, ap_denom, 1UL, MPFR_RNDN);
-		mpfr_div (ap_p_low, ap_p_low, ap_denom, MPFR_RNDN);
+		mpfr_ui_sub(ap_p_low, 1UL, ap_p_high, MPFR_RNDZ);
+		mpfr_ui_pow_ui (ap_denom, 2UL, n_in, MPFR_RNDZ);
+		mpfr_sub_ui(ap_denom, ap_denom, 1UL, MPFR_RNDZ);
+		mpfr_div (ap_p_low, ap_p_low, ap_denom, MPFR_RNDZ);
 
 		//Prior to moving on, calculate a reused power term
-		mpfr_ui_pow_ui(ap_power_term, 2UL, n_in - n, MPFR_RNDN);
+		mpfr_ui_pow_ui(ap_power_term, 2UL, n_in - n, MPFR_RNDZ);
 
 		//Step 3: Calculate Psi
-		mpfr_mul(ap_psi, ap_power_term, ap_p_low, MPFR_RNDN);
-		mpfr_add(ap_psi, ap_psi, ap_p_high,  MPFR_RNDN);
+		mpfr_mul(ap_psi, ap_power_term, ap_p_low, MPFR_RNDZ);
+		mpfr_add(ap_psi, ap_psi, ap_p_high,  MPFR_RNDZ);
 
 		//Step 4: Calculate U (goes into the ap_omega variable)
-		mpfr_log_ui(ap_omega, 2UL, MPFR_RNDN);
-		mpfr_mul(ap_omega, ap_omega, ap_power_term, MPFR_RNDN);
-		mpfr_mul_ui(ap_omega, ap_omega, 2UL*n, MPFR_RNDN);
-		mpfr_sqrt(ap_omega, ap_omega, MPFR_RNDN);
-		mpfr_add(ap_omega, ap_omega, ap_power_term,  MPFR_RNDN);
+		mpfr_log_ui(ap_omega, 2UL, MPFR_RNDZ);
+		mpfr_mul(ap_omega, ap_omega, ap_power_term, MPFR_RNDZ);
+		mpfr_mul_ui(ap_omega, ap_omega, 2UL*n, MPFR_RNDZ);
+		mpfr_sqrt(ap_omega, ap_omega, MPFR_RNDZ);
+		mpfr_add(ap_omega, ap_omega, ap_power_term,  MPFR_RNDZ);
 
 		//Step 5: Calculate omega
-		mpfr_mul(ap_omega, ap_omega, ap_p_low, MPFR_RNDN);
+		mpfr_mul(ap_omega, ap_omega, ap_p_low, MPFR_RNDZ);
 
 		//Step 6: Compare the values
 		if(mpfr_cmp(ap_omega, ap_psi) > 0) {
 			//omega > psi
-			mpfr_log2(ap_outputEntropy, ap_omega, MPFR_RNDN);
+			mpfr_log2(ap_outputEntropy, ap_omega, MPFR_RNDZ);
 		} else {
 			//omega <= psi
-			mpfr_log2(ap_outputEntropy, ap_psi, MPFR_RNDN);
+			mpfr_log2(ap_outputEntropy, ap_psi, MPFR_RNDZ);
 		}
 
 		//Keep -outputEntropy for calculation of log2epsilon
-		mpfr_set(ap_log2epsilon, ap_outputEntropy, MPFR_RNDN);
+		mpfr_set(ap_log2epsilon, ap_outputEntropy, MPFR_RNDZ);
 
 		//finalize outputEntropy
-		mpfr_neg(ap_outputEntropy, ap_outputEntropy, MPFR_RNDN);
+		mpfr_neg(ap_outputEntropy, ap_outputEntropy, MPFR_RNDZ);
 
-
+		//Could outputEntropy be valid?
 		if(mpfr_cmp_ui(ap_outputEntropy, n_out) >= 0) {
+			//outputEntropy appears to be greater than or equal to n_out
+			//This can't happen, and suggests there was a precision problem.
 			//Double the precision of everything and try again
 			adaquatePrecision = false;
 			precision = 2*precision;
@@ -185,21 +246,21 @@ int main(int argc, char* argv[]) {
 			continue;
 		}
 
-		outputEntropy = mpfr_get_ld(ap_outputEntropy, MPFR_RNDN);
+		outputEntropy = mpfr_get_ld(ap_outputEntropy, MPFR_RNDZ);
 
-		if(outputEntropy > 0.999 * (long double)n_out) {
+		if(outputEntropy > 0.999L * (long double)n_out) {
 			closeToFullEntropy = true;
 			//Calculate -log2(epsilon)
-			mpfr_div_ui(ap_log2epsilon, ap_log2epsilon, n_out, MPFR_RNDN);
-			mpfr_log1p(ap_log2epsilon, ap_log2epsilon, MPFR_RNDN);
+			mpfr_div_ui(ap_log2epsilon, ap_log2epsilon, n_out, MPFR_RNDZ);
+			mpfr_log1p(ap_log2epsilon, ap_log2epsilon, MPFR_RNDZ);
 			//Reuse ap_denom to hold log(2)
-			mpfr_log_ui(ap_denom, 2UL, MPFR_RNDN);
-			mpfr_div(ap_log2epsilon, ap_log2epsilon, ap_denom, MPFR_RNDN);
+			mpfr_log_ui(ap_denom, 2UL, MPFR_RNDZ);
+			mpfr_div(ap_log2epsilon, ap_log2epsilon, ap_denom, MPFR_RNDZ);
 			//Make it positive
-			mpfr_neg(ap_log2epsilon, ap_log2epsilon, MPFR_RNDN);
+			mpfr_neg(ap_log2epsilon, ap_log2epsilon, MPFR_RNDZ);
 
 			//Now convert back to a long double
-			epsilonExp = mpfr_get_ld(ap_log2epsilon, MPFR_RNDN);
+			epsilonExp = mpfr_get_ld(ap_log2epsilon, MPFR_RNDZ);
 
 			//Should this qualify as "full entropy" under the 2012 draft of SP800-90B?
 			if(mpfr_cmp_ui(ap_log2epsilon, 64) >= 0) {
@@ -208,11 +269,13 @@ int main(int argc, char* argv[]) {
 		}
 	}
 
+	assert((outputEntropy <= (long double)n_out) && (outputEntropy >= 0.0L));
+
 	//We're done with the calculation. Now print results.
 	if(vetted) {
 		printf("\n(Vetted) ");
 		if(closeToFullEntropy) {
-			if(outputEntropy == (long double)n_out) {
+			if(outputEntropy >= (long double)n_out) {
 				printf("h_out: Close to %.22Lg\n", outputEntropy);
 			} else {
 				printf("h_out: %.22Lg\n", outputEntropy);

--- a/cpp/conditioning_main.cpp
+++ b/cpp/conditioning_main.cpp
@@ -289,11 +289,12 @@ int main(int argc, char* argv[]) {
 	if(vetted) {
 		printf("(Vetted) ");
 		if(closeToFullEntropy) {
-			if(outputEntropy >= (long double)n_out) {
-				printf("h_out: Close to %.22Lg\n", outputEntropy);
+			if((outputEntropy >= (long double)n_out) || (nextafterl(outputEntropy, (long double)n_out) >= (long double)n_out)) {
+				printf("h_out: Close to %u\n", n_out);
 			} else {
 				printf("h_out: %.22Lg\n", outputEntropy);
 			}
+
 			printf("epsilon: 2^(-%.22Lg)", epsilonExp);
 			if(fullEntropy) {
 				printf(": SP800-90B 2012 Full Entropy\n");

--- a/cpp/restart_main.cpp
+++ b/cpp/restart_main.cpp
@@ -16,8 +16,7 @@
 
 [[ noreturn ]] void print_usage(){
 	printf("Usage is: ea_restart [-i|-n] [-v] <file_name> [bits_per_symbol] <H_I>\n\n");
-	printf("\t <file_name>: Must be relative path to a binary file with at least 1 million entries (samples),\n");
-	printf("\t and in the \"row dataset\" format described in SP800-90B Section 3.1.4.1.\n");
+	printf("\t <file_name>: Must be relative path to a binary file with at least 1 million entries (samples).\n");
 	printf("\t [bits_per_symbol]: Must be between 1-8, inclusive.\n");
 	printf("\t <H_I>: Initial entropy estimate.\n");
 	printf("\t [-i|-n]: '-i' for IID data, '-n' for non-IID data. Non-IID is the default.\n");

--- a/cpp/restart_main.cpp
+++ b/cpp/restart_main.cpp
@@ -16,7 +16,8 @@
 
 [[ noreturn ]] void print_usage(){
 	printf("Usage is: ea_restart [-i|-n] [-v] <file_name> [bits_per_symbol] <H_I>\n\n");
-	printf("\t <file_name>: Must be relative path to a binary file with at least 1 million entries (samples).\n");
+	printf("\t <file_name>: Must be relative path to a binary file with at least 1 million entries (samples),\n");
+	printf("\t and in the \"row dataset\" format described in SP800-90B Section 3.1.4.1.\n");
 	printf("\t [bits_per_symbol]: Must be between 1-8, inclusive.\n");
 	printf("\t <H_I>: Initial entropy estimate.\n");
 	printf("\t [-i|-n]: '-i' for IID data, '-n' for non-IID data. Non-IID is the default.\n");


### PR DESCRIPTION
Makes conditioning_main.cpp use arbitrary precision floating point (and only that). The same as #129, but without the documentation fixes (which will now be in pull request #137).

Makes conditioner render verdict with respect to the 2012 SP800-90B draft's definition of 'full entropy'; the use of the definition from this document is well marked: the tool's output message is "SP800-90B 2012 Full Entropy", so irrespective of how the final definition goes, this PR is still reasonable.

Our discussions with the SP800-90B authors at the CMUF Entropy Working Group indicate that the NIST authors intend a definition that is at least conceptually related to the one described here.

Resolves #128 