### PR TITLE
Fix error causing t-tuple underestimation with -i, -t and len > 1E6 symbols

### DIFF
--- a/cpp/non_iid_main.cpp
+++ b/cpp/non_iid_main.cpp
@@ -137,6 +137,7 @@ int main(int argc, char* argv[]){
 	}
 
 	if(!all_bits && (data.blen > MIN_SIZE)) data.blen = MIN_SIZE;
+	if(!all_bits && (data.len > MIN_SIZE)) data.len = MIN_SIZE;
 
 	if((verbose>0) && ((data.alph_size > 2) || !initial_entropy)) printf("Number of Binary Symbols: %ld\n", data.blen);
 	if(data.len < MIN_SIZE) printf("\n*** Warning: data contains less than %d samples ***\n\n", MIN_SIZE);


### PR DESCRIPTION
When the second call (conditioned with initial==True) to the t-tuple estimation occurs, SAalgs is called with the file length. When -t is used to truncate to 1,000,000 symbols and the file length is longer than 1,000,000 bytes, the length passed to SAalgs is not 1,000,000, but instead is the file length. This leads to an incorrect entropy estimation. This is not seen with the -c option since data.blen in used. In the -i case data.len is used. Around line 139 of non_iid_main.cpp, data.blen is appropriately truncated, but data.len is not.