### PR TITLE
Fix the calculation error in ea_iid.

### DIFF
--- a/cpp/shared/lrs_test.h
+++ b/cpp/shared/lrs_test.h
@@ -322,8 +322,9 @@ bool len_LRS_test(const byte data[], const int sample_size, const int alphabet_s
 	int lrs = len_LRS(data, sample_size);
 	int n = sample_size - lrs + 1;
 	long int overlap = n_choose_2(n);
+	long double pr_success = pow(p_col, lrs);
 
-	double pr_x = 1 - pow(1 - pow(p_col, lrs), overlap);
+	double pr_x = 1 - pow(1 - pr_success, overlap);
 
 	if(verbose > 0){
 		cout << label << "Longest Repeated Substring results" << endl;


### PR DESCRIPTION
When testing the conditioning component(lfsr) of LRNG, I observe a problem while
calculating the Pr (X ≥ 1)

Results

* P_col: 0.00390625
* Length of LRS: 7
* Pr(X >= 1): 0 => should not be 0

Pr (X ≥ 1) = 1 - pow(1 - pow(p_col, lrs), overlap)
if (1-pow(p_col, lrs)) store in a double type variable
would loss its precision.

Cause of the precision of different Floating-Point Types is
| Type        | Storage size | Value range            | Precision         |
|-------------|--------------|------------------------|-------------------|
| float       | 4 byte       | 1.2E-38 to 3.4E+38     | 6 decimal places  |
| double      | 8 byte       | 2.3E-308 to 1.7E+308   | 15 decimal places |
| long double | 10 byte      | 3.4E-4932 to 1.1E+4932 | 19 decimal places |

And the 1-pow(p_col, lrs) = 1 - 1.38778 x 10^(-17)
The decimal places is more than 15.
It would exceed the precision limit of double type.

After testing, literalLongest Repeated Substring results

* P_col: 0.00390625
* Length of LRS: 7
* Pr(X >= 1): 0.83781