### PR TITLE
Improved output and a small bug fix associated with the Compression Estimator

### DIFF
--- a/cpp/iid_main.cpp
+++ b/cpp/iid_main.cpp
@@ -116,9 +116,10 @@ int main(int argc, char* argv[]){
 		}
 	}
 
-	if(verbose > 0){
-		printf("Opening file: '%s'\n", file_path);
-	}
+        if(verbose>0) {
+                if(subsetSize == 0) printf("Opening file: '%s'\n", file_path);
+                else printf("Opening file: '%s', reading block %ld of size %ld\n", file_path, subsetIndex, subsetSize);
+        }
 
 	if(!read_file_subset(file_path, &data, subsetIndex, subsetSize)){
 		printf("Error reading file.\n");

--- a/cpp/non_iid_main.cpp
+++ b/cpp/non_iid_main.cpp
@@ -123,7 +123,10 @@ int main(int argc, char* argv[]){
 		}
 	}
 
-	if(verbose>0) printf("Opening file: '%s'\n", file_path);
+	if(verbose>0) {
+		if(subsetSize == 0) printf("Opening file: '%s'\n", file_path);
+		else printf("Opening file: '%s', reading block %ld of size %ld\n", file_path, subsetIndex, subsetSize);
+	}
 
 	if(!read_file_subset(file_path, &data, subsetIndex, subsetSize)){
 		printf("Error reading file.\n");
@@ -207,8 +210,10 @@ int main(int argc, char* argv[]){
 
 	if(initial_entropy && (data.alph_size == 2)) {
 		ret_min_entropy = compression_test(data.symbols, data.len, verbose, "Literal");
-		if(verbose == 1) printf("\ttCompression Test Estimate = %f / 1 bit(s)\n", ret_min_entropy);
-		H_original = min(ret_min_entropy, H_original);
+		if(ret_min_entropy >= 0) {
+			if(verbose == 1) printf("\ttCompression Test Estimate = %f / 1 bit(s)\n", ret_min_entropy);
+			H_original = min(ret_min_entropy, H_original);
+		}
 	}
 
 	if(verbose <= 1) printf("\nRunning Tuple Estimates...\n");

--- a/cpp/transpose_main.cpp
+++ b/cpp/transpose_main.cpp
@@ -65,7 +65,11 @@ int main(int argc, char* argv[])
 		print_usage();
 	}
 
-	if(verbose>0) printf("Opening input file: '%s'\n", argv[0]);
+        if(verbose>0) {
+                if(subsetSize == 0) printf("Opening input file: '%s'\n", argv[0]);
+                else printf("Opening file: '%s', reading block %ld of size %ld\n", argv[0], subsetIndex, subsetSize);
+        }
+
 
         if(!read_file_subset(argv[0], &data, subsetIndex, subsetSize)){
                 printf("Error reading file.\n");


### PR DESCRIPTION
The command line allows the user to select subsets of the data, but the output in verbose mode doesn't make it clear that such a subset is being tested. This PR makes the tools report the subset used in the output of `ea_iid`, `ea_non_iid`, and `ea_transpose`.

We also noticed a small bug that changed results in a somewhat unusual circumstance. In `ea_non_iid`, this PR causes the tool to only use the Compression Estimator result in the instance that this estimator has not returned an error.