### PR TITLE
A few changes to the merged JSON functionality.

### DIFF
--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -2,7 +2,7 @@ ARCH ?= x86
 
 CXX ?= $(CROSS_COMPILE)g++
 
-CXXFLAGS = -std=c++11 -fopenmp -O2 -ffloat-store
+CXXFLAGS = -std=c++11 -fopenmp -O2 -ffloat-store -I/usr/include/jsoncpp
 ifeq ($(ARCH),x86)
 CXXFLAGS += -msse2 -march=native
 endif

--- a/cpp/conditioning_main.cpp
+++ b/cpp/conditioning_main.cpp
@@ -356,9 +356,7 @@ static long double computeEntropyOfConditionedData(string inputfilename, bool ii
         // NON-IID path
         h_assessed = data.word_size;
         double ret_min_entropy = 0.0;
-        double h_original = data.word_size;
         double bin_t_tuple_res = -1.0, bin_lrs_res = -1.0;
-        double t_tuple_res = -1.0, lrs_res = -1.0;
 
         if (data.alph_size > 2) {
             
@@ -421,7 +419,7 @@ static long double computeEntropyOfConditionedData(string inputfilename, bool ii
 }
 
 int main(int argc, char* argv[]) {
-	bool vetted, quietMode = false, iid;
+	bool vetted, quietMode = false, iid=false;
 	long double h_p = -1.0L;
 	long double h_in, h_out; 
 	unsigned int n_in, n_out, nw, n;

--- a/cpp/conditioning_main.cpp
+++ b/cpp/conditioning_main.cpp
@@ -463,7 +463,7 @@ int main(int argc, char* argv[]) {
             	inputfilename = optarg;
             	break;
             case 'c':
-            	iid = (optarg == "iid");
+            	iid = (strcmp(optarg, "iid")==0);
             	break;
             default:
                 print_usage();

--- a/cpp/iid/chi_square_tests.h
+++ b/cpp/iid/chi_square_tests.h
@@ -648,7 +648,7 @@ bool chi_square_tests(const byte data[], const int sample_size, const int alphab
 	pvalue = chi_square_pvalue(score, df);
 
 	// Print results
-	if(verbose){
+	if(verbose > 1){
 		printf("Chi square independence\n");
 		printf("\tscore = %f\n", score);
 		printf("\tdegrees of freedom = %d\n", df);
@@ -674,7 +674,7 @@ bool chi_square_tests(const byte data[], const int sample_size, const int alphab
 	pvalue = chi_square_pvalue(score, df);
 
 	// Print results
-	if(verbose){
+	if(verbose > 1){
 		printf("Chi square goodness of fit\n");
 		printf("\tscore = %f\n", score);
 		printf("\tdegrees of freedom = %d\n", df);

--- a/cpp/iid/iid_test_case.h
+++ b/cpp/iid/iid_test_case.h
@@ -3,7 +3,7 @@
 
 #include <cstdlib>
 #include <vector> 
-#include <jsoncpp/json/json.h>
+#include <json/json.h>
 
 #include "permutation_test_result.h"
 #include "../shared/test_case_base.h"
@@ -47,7 +47,7 @@ public:
             json["h_i"] = h_i;
 
         Json::Value permutationTestResults;
-        for (int i = 0; i < testResults.size(); i++) {
+        for (int i = 0; i < (int)testResults.size(); i++) {
             permutationTestResults[i] = testResults[i].GetAsJson();
         }
 

--- a/cpp/iid/iid_test_case.h
+++ b/cpp/iid/iid_test_case.h
@@ -32,14 +32,12 @@ public:
             json["mean"] = mean;
         if (median != -1)
             json["median"] = median;
-        if (binary != -1)
+        if (binary)
             json["binary"] = binary;
-        if (passed_chi_square_tests != -1)
-            json["passedChiSquareTests"] = passed_chi_square_tests;
-        if (passed_longest_repeated_substring_test != -1)
-            json["passedLongestRepeatedSubstringTest"] = passed_longest_repeated_substring_test;
-        if (passed_iid_permutation_tests != -1)
-            json["passedIidPermutationTests"] = passed_iid_permutation_tests;
+
+        json["passedChiSquareTests"] = passed_chi_square_tests;
+        json["passedLongestRepeatedSubstringTest"] = passed_longest_repeated_substring_test;
+        json["passedIidPermutationTests"] = passed_iid_permutation_tests;
 
         if (h_r != -1)
             json["h_r"] = h_r;

--- a/cpp/iid/iid_test_run.h
+++ b/cpp/iid/iid_test_run.h
@@ -15,7 +15,7 @@ public:
         json["IID"] = IID;
 
         Json::Value testCasesJson;
-        for (int i = 0; i < testCases.size(); i++){
+        for (int i = 0; i < (int)testCases.size(); i++){
             testCasesJson[i] = testCases[i].GetAsJson();
         }
 

--- a/cpp/iid/permutation_test_result.h
+++ b/cpp/iid/permutation_test_result.h
@@ -3,7 +3,7 @@
 
 #include <cstdlib>
 #include <string>
-#include <jsoncpp/json/json.h>
+#include <json/json.h>
 
 using namespace std;
 

--- a/cpp/iid/permutation_tests.h
+++ b/cpp/iid/permutation_tests.h
@@ -600,12 +600,12 @@ bool permutation_tests(const data_t *dp, const double rawmean, const double medi
 	}
 
 	// Run initial tests
-	if(verbose) cout << "Beginning initial tests..." << endl;
+	if(verbose > 1) cout << "Beginning initial tests..." << endl;
 	seed(xoshiro256starstarMainSeed);
 
 	run_tests(dp, dp->symbols, dp->rawsymbols, rawmean, median, t, test_status);
 
-	if(verbose){
+	if(verbose > 1){
 		cout << endl << "Initial test results" << endl;
 		for(unsigned int i = 0; i < num_tests; i++){
 			cout << setw(23) << test_names[i] << ": ";
@@ -614,7 +614,7 @@ bool permutation_tests(const data_t *dp, const double rawmean, const double medi
 		cout << endl;
 	}
 	
-	if(verbose) cout << "Beginning permutation tests... these may take some time" << endl;
+	if(verbose > 1) cout << "Beginning permutation tests... these may take some time" << endl;
 
 	#pragma omp parallel
 	{
@@ -673,7 +673,7 @@ bool permutation_tests(const data_t *dp, const double rawmean, const double medi
 					completed ++;
 				} // end resultUpdate
 
-				if(verbose){
+				if(verbose > 1) {
 					int res;
 					/* Construct pretty output regardless of whether on terminal (tty) or 
 					* redirected to another file descriptor (eg. redirect to file).
@@ -722,7 +722,7 @@ bool permutation_tests(const data_t *dp, const double rawmean, const double medi
         	delete[](rawdata);
 	} //end parallel
 
-	if(verbose) print_results(C);
+	if(verbose > 1) print_results(C);
         
     populateTestCase(tc, C);
 	

--- a/cpp/iid/permutation_tests.h
+++ b/cpp/iid/permutation_tests.h
@@ -285,7 +285,6 @@ unsigned long int covariance(const byte data[], const unsigned int p, const unsi
 //
 // Can handle binary and non-binary data
 unsigned int compression(const byte data[], const int sample_size, const byte max_symbol){
-	char buffer[5];
 	char *msg;
 	unsigned int curlen = 0;
 	char *curmsg;

--- a/cpp/iid_main.cpp
+++ b/cpp/iid_main.cpp
@@ -52,7 +52,7 @@
 int main(int argc, char* argv[]){
 
 	bool initial_entropy, all_bits;
-	int verbose = 0;
+	int verbose = 1;  //verbose 0 is for JSON output, 1 is the normal mode, 2 is the NIST tool verbose mode, and 3 is for extra verbose output
 	double rawmean, median;
 	char* file_path;
 	data_t data;
@@ -157,7 +157,7 @@ int main(int argc, char* argv[]){
 		}
 	}
 
-    if(verbose > 0) {
+    if(verbose > 1) {
         if(subsetSize == 0) {
             printf("Opening file: '%s'\n", file_path);
         } else {
@@ -186,7 +186,7 @@ int main(int argc, char* argv[]){
 		print_usage();
 	}
 
-	if(verbose > 0) printf("Loaded %ld samples of %d distinct %d-bit-wide symbols\n", data.len, data.alph_size, data.word_size);
+	if(verbose > 1) printf("Loaded %ld samples of %d distinct %d-bit-wide symbols\n", data.len, data.alph_size, data.word_size);
 
 	if(data.alph_size <= 1) {
 
@@ -207,9 +207,9 @@ int main(int argc, char* argv[]){
 
 	if(!all_bits && (data.blen > MIN_SIZE)) data.blen = MIN_SIZE;
 
-	if((verbose > 0) && ((data.alph_size > 2) || !initial_entropy)) printf("Number of Binary samples: %ld\n", data.blen);
+	if((verbose > 1) && ((data.alph_size > 2) || !initial_entropy)) printf("Number of Binary samples: %ld\n", data.blen);
 	if(data.len < MIN_SIZE) printf("\n*** Warning: data contains less than %d samples ***\n\n", MIN_SIZE);
-	if(verbose > 0) {
+	if(verbose > 1) {
 		if(data.alph_size < (1 << data.word_size)) printf("\nSamples have been translated\n");
 	}
 
@@ -217,12 +217,12 @@ int main(int argc, char* argv[]){
 	int alphabet_size = data.alph_size;
 	int sample_size = data.len;
 
-    if (!quietMode)
+    if (verbose >= 1)
 	   printf("Calculating baseline statistics...\n");
 	
     calc_stats(&data, rawmean, median);
 
-	if(verbose > 0){
+	if(verbose > 1){
 		printf("\tRaw Mean: %f\n", rawmean);
 		printf("\tMedian: %f\n", median);
 		printf("\tBinary: %s\n\n", (alphabet_size == 2 ? "true" : "false"));
@@ -248,20 +248,17 @@ int main(int argc, char* argv[]){
     tc.h_bitstring = H_bitstring;
     
     double h_assessed = data.word_size;
-    if(verbose <= 1) {
-        if (!quietMode) {
-            if(initial_entropy) {
-                
-                printf("H_original: %f\n", H_original);
-                if(data.alph_size > 2) {
-                    printf("H_bitstring: %f\n", H_bitstring);
-                    printf("min(H_original, %d X H_bitstring): %f\n", data.word_size, min(H_original, data.word_size*H_bitstring));
-                }
-            } else {
-                printf("h': %f\n", H_bitstring);
+    if((verbose == 1) || (verbose == 2)) {
+        if(initial_entropy) {
+            printf("H_original: %f\n", H_original);
+            if(data.alph_size > 2) {
+                printf("H_bitstring: %f\n", H_bitstring);
+                printf("min(H_original, %d X H_bitstring): %f\n", data.word_size, min(H_original, data.word_size*H_bitstring));
             }
+        } else {
+            printf("h': %f\n", H_bitstring);
         }
-    } else {
+    } else if(verbose > 2) {
         h_assessed = data.word_size;
 
         if((data.alph_size > 2) || !initial_entropy) {
@@ -282,7 +279,7 @@ int main(int argc, char* argv[]){
     bool chi_square_test_pass = chi_square_tests(data.symbols, sample_size, alphabet_size, verbose);
     tc.passed_chi_square_tests = chi_square_test_pass;
 
-    if (!quietMode) {
+    if (verbose > 0) {
         if (chi_square_test_pass) {
             printf("** Passed chi square tests\n\n");
         } else {
@@ -294,7 +291,7 @@ int main(int argc, char* argv[]){
     bool len_LRS_test_pass = len_LRS_test(data.symbols, sample_size, alphabet_size, verbose, "Literal");
     tc.passed_longest_repeated_substring_test = len_LRS_test_pass;
 
-    if (!quietMode) {
+    if (verbose>0) {
         if (len_LRS_test_pass) {
             printf("** Passed length of longest repeated substring test\n\n");
         } else {
@@ -306,7 +303,7 @@ int main(int argc, char* argv[]){
     bool perm_test_pass = permutation_tests(&data, rawmean, median, verbose, tc);
     tc.passed_iid_permutation_tests = perm_test_pass;
 
-    if (!quietMode) {
+    if (verbose > 0) {
         if (perm_test_pass) {
             printf("** Passed IID permutation tests\n\n");
         } else {

--- a/cpp/non_iid/collision_test.h
+++ b/cpp/non_iid/collision_test.h
@@ -41,11 +41,11 @@ double collision_test(byte* data, long len, const int verbose, const char *label
 	// X is mean of t_v's, s is sample stdev, where
 	// s^2 = (sum(t_v^2) - sum(t_v)^2/v) / (v-1)
 	X = i / (double)v;
-	if(verbose == 1) printf("%s Collision Estimate: X-bar = %.17g, ", label, X);
+	if(verbose == 2) printf("%s Collision Estimate: X-bar = %.17g, ", label, X);
 	s = sqrt((s - (i*X)) / (v-1));
-	if(verbose == 1) printf("sigma-hat = %.17g, ", s);
+	if(verbose == 2) printf("sigma-hat = %.17g, ", s);
 
-	if(verbose == 2) {
+	if(verbose == 3) {
 		printf("%s Collision Estimate: v = %ld\n", label, v);
 		printf("%s Collision Estimate: Sum t_i = %ld\n", label, i);
 		printf("%s Collision Estimate: X-bar = %.17g\n", label, X);
@@ -57,7 +57,7 @@ double collision_test(byte* data, long len, const int verbose, const char *label
 	//2 is the smallest meaninful value here.
 	if(X < 2.0) X = 2.0;
 
-	if(verbose == 2)
+	if(verbose == 3)
 		printf("%s Collision Estimate: X-bar' = %.17g\n", label, X);
 
 	//Uyen Dinh observed that (with the simpler F function described in UL comments) we can simplify the entire expression much further than in 90B.
@@ -67,15 +67,15 @@ double collision_test(byte* data, long len, const int verbose, const char *label
 	if(X < 2.5) {
 		p = 0.5 + sqrt(1.25 - 0.5 * X);
 		entEst = -log2(p);
-		if(verbose == 2) printf("%s Collision Estimate: Found p.\n", label);
+		if(verbose == 3) printf("%s Collision Estimate: Found p.\n", label);
 	} else {
-		if(verbose == 2) printf("%s Collision Estimate: Could Not Find p. Proceeding with the lower bound for p.\n", label);
+		if(verbose == 3) printf("%s Collision Estimate: Could Not Find p. Proceeding with the lower bound for p.\n", label);
 		p = 0.5;
 		entEst = 1.0;
 	}
 
-	if(verbose == 1) printf("p = %.17g\n", p);
-	else if(verbose == 2) {
+	if(verbose == 2) printf("p = %.17g\n", p);
+	else if(verbose == 3) {
 		printf("%s Collision Estimate: p = %.17g\n", label, p);
 		printf("%s Collision Estimate: min entropy = %.17g\n", label, entEst);
 	}

--- a/cpp/non_iid/collision_test.h
+++ b/cpp/non_iid/collision_test.h
@@ -15,12 +15,9 @@ double col_exp(double p){
 // Section 6.3.2 - Collision Estimate
 // data is assumed to be binary (e.g., bit string)
 double collision_test(byte* data, long len, const int verbose, const char *label){
-	long v, i, j;
+	long v, i;
 	int t_v;
-	double X, s, p, lastP, pVal;
-        double lvalue, hvalue;
-        double hbound, lbound;
-        double hdomain, ldomain;
+	double X, s, p;
 	double entEst;
 
 	i = 0;

--- a/cpp/non_iid/compression_test.h
+++ b/cpp/non_iid/compression_test.h
@@ -130,10 +130,10 @@ double compression_test(byte* data, long len, const int verbose, const char *lab
 	X /= v;
 	sigma = 0.5907 * sqrt(sigma/(v-1.0) - X*X);
 
-	if(verbose == 1) {
+	if(verbose == 2) {
 		printf("%s Compression Estimate: X-bar = %.17g, ", label, X);
 		printf("sigma-hat = %.17g, ", sigma);
-	} else if(verbose == 2) {
+	} else if(verbose == 3) {
 		printf("%s Compression Estimate: X-bar = %.17g\n", label, X);
 		printf("%s Compression Estimate: sigma-hat = %.17g\n", label, sigma);
 	}
@@ -141,7 +141,7 @@ double compression_test(byte* data, long len, const int verbose, const char *lab
         // binary search for p
 	X -= ZALPHA * sigma/sqrt(v);
 
-	if(verbose == 2) printf("%s Compression Estimate: X-bar' = %.17g\n", label, X);
+	if(verbose == 3) printf("%s Compression Estimate: X-bar' = %.17g\n", label, X);
 
 	if(com_exp(1.0/(double)alph_size, alph_size, d, num_blocks) > X) {
 		ldomain = 1.0 / (double)alph_size;
@@ -228,15 +228,15 @@ double compression_test(byte* data, long len, const int verbose, const char *lab
 	if(p > 1.0 / (double)alph_size) {
         	entEst = -log2(p)/b;
 	
-		if(verbose == 2) printf("%s Compression Estimate: Found p.\n", label);
+		if(verbose == 3) printf("%s Compression Estimate: Found p.\n", label);
 	} else {
 		p = 1.0 / (double)alph_size;
 		entEst = 1.0;
-		if(verbose == 2) printf("%s Compression Estimate: Could Not Find p. Proceeding with the lower bound for p.\n", label);
+		if(verbose == 3) printf("%s Compression Estimate: Could Not Find p. Proceeding with the lower bound for p.\n", label);
 	}
 
-	if(verbose == 1) printf("p = %.17g\n", p);
-	else if(verbose == 2) {
+	if(verbose == 2) printf("p = %.17g\n", p);
+	else if(verbose == 3) {
 		printf("%s Compression Estimate: p = %.17g\n", label, p);
 		printf("%s Compression Estimate: min entropy = %.17g\n", label, entEst);
 	}

--- a/cpp/non_iid/markov_test.h
+++ b/cpp/non_iid/markov_test.h
@@ -51,8 +51,8 @@ double markov_test(byte* data, long len, const int verbose, const char *label){
 	P_0 = C_0 / (double)len;
 	P_1 = 1.0 - P_0;
 
-	if(verbose == 1) printf("%s Markov Estimate: P_0 = %.17g, P_1 = %.17g, P_0,0 = %.17g, P_0,1 = %.17g, P_1,0 = %.17g, P_1,1 = %.17g, ", label, P_0, P_1, P_00, P_01, P_10, P_11);
-	else if(verbose == 2) {
+	if(verbose == 2) printf("%s Markov Estimate: P_0 = %.17g, P_1 = %.17g, P_0,0 = %.17g, P_0,1 = %.17g, P_1,0 = %.17g, P_1,1 = %.17g, ", label, P_0, P_1, P_00, P_01, P_10, P_11);
+	else if(verbose == 3) {
 		printf("%s Markov Estimate: P_0 = %.17g\n", label, P_0);
 		printf("%s Markov Estimate: P_1 = %.17g\n", label, P_1);
 		printf("%s Markov Estimate: P_{0,0} = %.17g\n", label, P_00);
@@ -104,8 +104,8 @@ double markov_test(byte* data, long len, const int verbose, const char *label){
 
 	entEst = fmin(H_min/128.0, 1.0);
 
-	if(verbose == 1) printf("p_max = %.17g\n", pow(2.0, -H_min));
-	else if(verbose == 2) {
+	if(verbose == 2) printf("p_max = %.17g\n", pow(2.0, -H_min));
+	else if(verbose == 3) {
 		printf("%s Markov Estimate: p-hat_max = %.17g\n", label, pow(2.0, -H_min));
 		printf("%s Markov Estimate: min entropy = %.17g\n", label, entEst);
 	}

--- a/cpp/non_iid/non_iid_test_case.h
+++ b/cpp/non_iid/non_iid_test_case.h
@@ -2,7 +2,7 @@
 #define NONIIDTESTCASE_H
 
 #include <string>
-#include <jsoncpp/json/json.h>
+#include <json/json.h>
 
 #include "../shared/test_case_base.h"
 

--- a/cpp/non_iid/non_iid_test_run.h
+++ b/cpp/non_iid/non_iid_test_run.h
@@ -3,7 +3,7 @@
 
 #include <string>
 #include <vector>
-#include <jsoncpp/json/json.h>
+#include <json/json.h>
 
 #include "../shared/test_run_base.h"
 #include "non_iid_test_case.h"
@@ -17,7 +17,7 @@ public:
         json["IID"] = IID;
 
         Json::Value testCasesJson;
-        for (int i = 0; i < testCases.size(); i++){
+        for (int i = 0; i < (int)testCases.size(); i++){
             testCasesJson[i] = testCases[i].GetAsJson();
         }
 

--- a/cpp/non_iid_main.cpp
+++ b/cpp/non_iid_main.cpp
@@ -55,7 +55,7 @@
 
 int main(int argc, char* argv[]) {
     bool initial_entropy, all_bits;
-    int verbose = 0;
+    int verbose = 1; //verbose 0 is for JSON output, 1 is the normal mode, 2 is the NIST tool verbose mode, and 3 is for extra verbose output
     bool quietMode = false;
     char *file_path;
     double H_original, H_bitstring, ret_min_entropy;
@@ -156,7 +156,7 @@ int main(int argc, char* argv[]) {
         }
     }
 
-    if(verbose>0) {
+    if(verbose>1) {
         if(subsetSize == 0) printf("Opening file: '%s'\n", file_path);
         else printf("Opening file: '%s', reading block %ld of size %ld\n", file_path, subsetIndex, subsetSize);
     }
@@ -177,7 +177,7 @@ int main(int argc, char* argv[]) {
         print_usage();
     }
 
-    if (verbose > 0) printf("Loaded %ld samples of %d distinct %d-bit-wide symbols\n", data.len, data.alph_size, data.word_size);
+    if (verbose > 1) printf("Loaded %ld samples of %d distinct %d-bit-wide symbols\n", data.len, data.alph_size, data.word_size);
 
     if (data.alph_size <= 1) {
 
@@ -199,9 +199,9 @@ int main(int argc, char* argv[]) {
 
     if (!all_bits && (data.blen > MIN_SIZE)) data.blen = MIN_SIZE;
 
-    if ((verbose > 0) && ((data.alph_size > 2) || !initial_entropy)) printf("Number of Binary Symbols: %ld\n", data.blen);
+    if ((verbose > 1) && ((data.alph_size > 2) || !initial_entropy)) printf("Number of Binary Symbols: %ld\n", data.blen);
     if (data.len < MIN_SIZE) printf("\n*** Warning: data contains less than %d samples ***\n\n", MIN_SIZE);
-    if (verbose > 0) {
+    if (verbose > 1) {
         if (data.alph_size < (1 << data.word_size)) printf("\nSymbols have been translated.\n");
     }
 
@@ -210,7 +210,7 @@ int main(int argc, char* argv[]) {
     H_original = data.word_size;
     H_bitstring = 1.0;
 
-    if (verbose >= 1) {
+    if ((verbose == 1) || (verbose == 2)) {
         printf("\nRunning non-IID tests...\n\n");
         printf("Running Most Common Value Estimate...\n");
     }
@@ -220,14 +220,14 @@ int main(int argc, char* argv[]) {
 
     if (((data.alph_size > 2) || !initial_entropy)) {
         ret_min_entropy = most_common(data.bsymbols, data.blen, 2, verbose, "Bitstring", tc631);
-        if (verbose == 1) printf("\tMost Common Value Estimate (bit string) = %f / 1 bit(s)\n", ret_min_entropy);
+        if (verbose == 2) printf("\tMost Common Value Estimate (bit string) = %f / 1 bit(s)\n", ret_min_entropy);
         H_bitstring = min(ret_min_entropy, H_bitstring);
         tc631.h_bitstring = ret_min_entropy;
     }
 
     if (initial_entropy) {
         ret_min_entropy = most_common(data.symbols, data.len, data.alph_size, verbose, "Literal", tc631);
-        if (verbose == 1) printf("\tMost Common Value Estimate = %f / %d bit(s)\n", ret_min_entropy, data.word_size);
+        if (verbose == 2) printf("\tMost Common Value Estimate = %f / %d bit(s)\n", ret_min_entropy, data.word_size);
         H_original = min(ret_min_entropy, H_original);
         tc631.h_original = ret_min_entropy;
     }
@@ -238,18 +238,18 @@ int main(int argc, char* argv[]) {
     // Section 6.3.2 - Estimate entropy with Collision Test (for bit strings only)
     NonIidTestCase tc632;
 
-    if (verbose >= 1) printf("\nRunning Entropic Statistic Estimates (bit strings only)...\n");
+    if ((verbose == 1) || (verbose == 2)) printf("\nRunning Entropic Statistic Estimates (bit strings only)...\n");
 
     if (((data.alph_size > 2) || !initial_entropy)) {
         ret_min_entropy = collision_test(data.bsymbols, data.blen, verbose, "Bitstring");
-        if (verbose == 1) printf("\tCollision Test Estimate (bit string) = %f / 1 bit(s)\n", ret_min_entropy);
+        if (verbose == 2) printf("\tCollision Test Estimate (bit string) = %f / 1 bit(s)\n", ret_min_entropy);
         H_bitstring = min(ret_min_entropy, H_bitstring);
         tc632.h_bitstring = ret_min_entropy;
     }
 
     if (initial_entropy && (data.alph_size == 2)) {
         ret_min_entropy = collision_test(data.symbols, data.len, verbose, "Literal");
-        if (verbose == 1) printf("\tCollision Test Estimate = %f / 1 bit(s)\n", ret_min_entropy);
+        if (verbose == 2) printf("\tCollision Test Estimate = %f / 1 bit(s)\n", ret_min_entropy);
         H_original = min(ret_min_entropy, H_original);
         tc632.h_original = ret_min_entropy;
     }
@@ -262,14 +262,14 @@ int main(int argc, char* argv[]) {
 
     if (((data.alph_size > 2) || !initial_entropy)) {
         ret_min_entropy = markov_test(data.bsymbols, data.blen, verbose, "Bitstring");
-        if (verbose == 1) printf("\tMarkov Test Estimate (bit string) = %f / 1 bit(s)\n", ret_min_entropy);
+        if (verbose == 2) printf("\tMarkov Test Estimate (bit string) = %f / 1 bit(s)\n", ret_min_entropy);
         H_bitstring = min(ret_min_entropy, H_bitstring);
         tc633.h_bitstring = ret_min_entropy;
     }
 
     if (initial_entropy && (data.alph_size == 2)) {
         ret_min_entropy = markov_test(data.symbols, data.len, verbose, "Literal");
-        if (verbose == 1) printf("\tMarkov Test Estimate = %f / 1 bit(s)\n", ret_min_entropy);
+        if (verbose == 2) printf("\tMarkov Test Estimate = %f / 1 bit(s)\n", ret_min_entropy);
         H_original = min(ret_min_entropy, H_original);
         tc633.h_original = ret_min_entropy;
     }
@@ -283,7 +283,7 @@ int main(int argc, char* argv[]) {
     if (((data.alph_size > 2) || !initial_entropy)) {
         ret_min_entropy = compression_test(data.bsymbols, data.blen, verbose, "Bitstring");
         if (ret_min_entropy >= 0) {
-            if (verbose == 1) printf("\tCompression Test Estimate (bit string) = %f / 1 bit(s)\n", ret_min_entropy);
+            if (verbose == 2) printf("\tCompression Test Estimate (bit string) = %f / 1 bit(s)\n", ret_min_entropy);
             H_bitstring = min(ret_min_entropy, H_bitstring);
             tc634.h_bitstring = ret_min_entropy;
         }
@@ -292,7 +292,7 @@ int main(int argc, char* argv[]) {
     if (initial_entropy && (data.alph_size == 2)) {
         ret_min_entropy = compression_test(data.symbols, data.len, verbose, "Literal");
         if (ret_min_entropy >= 0) {
-            if (verbose == 1) printf("\tCompression Test Estimate = %f / 1 bit(s)\n", ret_min_entropy);
+            if (verbose == 2) printf("\tCompression Test Estimate = %f / 1 bit(s)\n", ret_min_entropy);
             H_original = min(ret_min_entropy, H_original);
             tc634.h_original = ret_min_entropy;
         }
@@ -304,12 +304,12 @@ int main(int argc, char* argv[]) {
     // Section 6.3.5 - Estimate entropy with t-Tuple Test
     NonIidTestCase tc635;
 
-    if (verbose >= 1 ) printf("\nRunning Tuple Estimates...\n");
+    if ((verbose == 1) || (verbose == 2)) printf("\nRunning Tuple Estimates...\n");
     
     if (((data.alph_size > 2) || !initial_entropy)) {
         SAalgs(data.bsymbols, data.blen, 2, bin_t_tuple_res, bin_lrs_res, verbose, "Bitstring");
         if (bin_t_tuple_res >= 0.0) {
-            if (verbose == 1) printf("\tT-Tuple Test Estimate (bit string) = %f / 1 bit(s)\n", bin_t_tuple_res);
+            if (verbose == 2) printf("\tT-Tuple Test Estimate (bit string) = %f / 1 bit(s)\n", bin_t_tuple_res);
             H_bitstring = min(bin_t_tuple_res, H_bitstring);
             tc635.bin_t_tuple_res = bin_t_tuple_res;
         }
@@ -318,7 +318,7 @@ int main(int argc, char* argv[]) {
     if (initial_entropy) {
         SAalgs(data.symbols, data.len, data.alph_size, t_tuple_res, lrs_res, verbose, "Literal");
         if (t_tuple_res >= 0.0) {
-            if (verbose == 1) printf("\tT-Tuple Test Estimate = %f / %d bit(s)\n", t_tuple_res, data.word_size);
+            if (verbose == 2) printf("\tT-Tuple Test Estimate = %f / %d bit(s)\n", t_tuple_res, data.word_size);
             H_original = min(t_tuple_res, H_original);
             tc635.t_tuple_res = t_tuple_res;
         }
@@ -331,13 +331,13 @@ int main(int argc, char* argv[]) {
     NonIidTestCase tc636;
 
     if ((((data.alph_size > 2) || !initial_entropy)) && (bin_lrs_res >= 0.0)) {
-        if (verbose == 1) printf("\tLRS Test Estimate (bit string) = %f / 1 bit(s)\n", bin_lrs_res);
+        if (verbose == 2) printf("\tLRS Test Estimate (bit string) = %f / 1 bit(s)\n", bin_lrs_res);
         H_bitstring = min(bin_lrs_res, H_bitstring);
         tc636.bin_lrs_res = bin_lrs_res;
     }
 
     if (initial_entropy && (lrs_res >= 0.0)) {
-        if (verbose == 1) printf("\tLRS Test Estimate = %f / %d bit(s)\n", lrs_res, data.word_size);
+        if (verbose == 2) printf("\tLRS Test Estimate = %f / %d bit(s)\n", lrs_res, data.word_size);
         H_original = min(lrs_res, H_original);
         tc636.lrs_res = lrs_res;
     }
@@ -348,12 +348,12 @@ int main(int argc, char* argv[]) {
     // Section 6.3.7 - Estimate entropy with Multi Most Common in Window Test
     NonIidTestCase tc637;
 
-    if (verbose <= 1 && !quietMode) printf("\nRunning Predictor Estimates...\n");
+    if ((verbose == 1) || (verbose == 2)) printf("\nRunning Predictor Estimates...\n");
 
     if (((data.alph_size > 2) || !initial_entropy)) {
         ret_min_entropy = multi_mcw_test(data.bsymbols, data.blen, 2, verbose, "Bitstring");
         if (ret_min_entropy >= 0) {
-            if (verbose == 1) printf("\tMulti Most Common in Window (MultiMCW) Prediction Test Estimate (bit string) = %f / 1 bit(s)\n", ret_min_entropy);
+            if (verbose == 2) printf("\tMulti Most Common in Window (MultiMCW) Prediction Test Estimate (bit string) = %f / 1 bit(s)\n", ret_min_entropy);
             H_bitstring = min(ret_min_entropy, H_bitstring);
             tc637.h_bitstring = ret_min_entropy;
         }
@@ -362,7 +362,7 @@ int main(int argc, char* argv[]) {
     if (initial_entropy) {
         ret_min_entropy = multi_mcw_test(data.symbols, data.len, data.alph_size, verbose, "Literal");
         if (ret_min_entropy >= 0) {
-            if (verbose == 1) printf("\tMulti Most Common in Window (MultiMCW) Prediction Test Estimate = %f / %d bit(s)\n", ret_min_entropy, data.word_size);
+            if (verbose == 2) printf("\tMulti Most Common in Window (MultiMCW) Prediction Test Estimate = %f / %d bit(s)\n", ret_min_entropy, data.word_size);
             H_original = min(ret_min_entropy, H_original);
             tc637.h_original = ret_min_entropy;
         }
@@ -377,7 +377,7 @@ int main(int argc, char* argv[]) {
     if (((data.alph_size > 2) || !initial_entropy)) {
         ret_min_entropy = lag_test(data.bsymbols, data.blen, 2, verbose, "Bitstring");
         if (ret_min_entropy >= 0) {
-            if (verbose == 1) printf("\tLag Prediction Test Estimate (bit string) = %f / 1 bit(s)\n", ret_min_entropy);
+            if (verbose == 2) printf("\tLag Prediction Test Estimate (bit string) = %f / 1 bit(s)\n", ret_min_entropy);
             H_bitstring = min(ret_min_entropy, H_bitstring);
             tc638.h_bitstring = ret_min_entropy;
         }
@@ -386,7 +386,7 @@ int main(int argc, char* argv[]) {
     if (initial_entropy) {
         ret_min_entropy = lag_test(data.symbols, data.len, data.alph_size, verbose, "Literal");
         if (ret_min_entropy >= 0) {
-            if (verbose == 1) printf("\tLag Prediction Test Estimate = %f / %d bit(s)\n", ret_min_entropy, data.word_size);
+            if (verbose == 2) printf("\tLag Prediction Test Estimate = %f / %d bit(s)\n", ret_min_entropy, data.word_size);
             H_original = min(ret_min_entropy, H_original);
             tc638.h_original = ret_min_entropy;
         }
@@ -401,7 +401,7 @@ int main(int argc, char* argv[]) {
     if (((data.alph_size > 2) || !initial_entropy)) {
         ret_min_entropy = multi_mmc_test(data.bsymbols, data.blen, 2, verbose, "Bitstring");
         if (ret_min_entropy >= 0) {
-            if (verbose == 1) printf("\tMulti Markov Model with Counting (MultiMMC) Prediction Test Estimate (bit string) = %f / 1 bit(s)\n", ret_min_entropy);
+            if (verbose == 2) printf("\tMulti Markov Model with Counting (MultiMMC) Prediction Test Estimate (bit string) = %f / 1 bit(s)\n", ret_min_entropy);
             H_bitstring = min(ret_min_entropy, H_bitstring);
             tc639.h_bitstring = ret_min_entropy;
         }
@@ -410,7 +410,7 @@ int main(int argc, char* argv[]) {
     if (initial_entropy) {
         ret_min_entropy = multi_mmc_test(data.symbols, data.len, data.alph_size, verbose, "Literal");
         if (ret_min_entropy >= 0) {
-            if (verbose == 1) printf("\tMulti Markov Model with Counting (MultiMMC) Prediction Test Estimate = %f / %d bit(s)\n", ret_min_entropy, data.word_size);
+            if (verbose == 2) printf("\tMulti Markov Model with Counting (MultiMMC) Prediction Test Estimate = %f / %d bit(s)\n", ret_min_entropy, data.word_size);
             H_original = min(ret_min_entropy, H_original);
             tc639.h_original = ret_min_entropy;
         }
@@ -425,7 +425,7 @@ int main(int argc, char* argv[]) {
     if (((data.alph_size > 2) || !initial_entropy)) {
         ret_min_entropy = LZ78Y_test(data.bsymbols, data.blen, 2, verbose, "Bitstring");
         if (ret_min_entropy >= 0) {
-            if (verbose == 1) printf("\tLZ78Y Prediction Test Estimate (bit string) = %f / 1 bit(s)\n", ret_min_entropy);
+            if (verbose == 2) printf("\tLZ78Y Prediction Test Estimate (bit string) = %f / 1 bit(s)\n", ret_min_entropy);
             H_bitstring = min(ret_min_entropy, H_bitstring);
             tc6310.h_bitstring = ret_min_entropy;
         }
@@ -434,7 +434,7 @@ int main(int argc, char* argv[]) {
     if (initial_entropy) {
         ret_min_entropy = LZ78Y_test(data.symbols, data.len, data.alph_size, verbose, "Literal");
         if (ret_min_entropy >= 0) {
-            if (verbose == 1) printf("\tLZ78Y Prediction Test Estimate = %f / %d bit(s)\n", ret_min_entropy, data.word_size);
+            if (verbose == 2) printf("\tLZ78Y Prediction Test Estimate = %f / %d bit(s)\n", ret_min_entropy, data.word_size);
             H_original = min(ret_min_entropy, H_original);
             tc6310.h_original = ret_min_entropy;
         }
@@ -454,20 +454,17 @@ int main(int argc, char* argv[]) {
         h_assessed = min(h_assessed, H_original);
     }
 
-    if(verbose <= 1) {
-        if (!quietMode) {
-            if(initial_entropy) {
-                
-                printf("H_original: %f\n", H_original);
-                if(data.alph_size > 2) {
-                    printf("H_bitstring: %f\n", H_bitstring);
-                    printf("min(H_original, %d X H_bitstring): %f\n", data.word_size, min(H_original, data.word_size*H_bitstring));
-                }
-            } else {
-                printf("h': %f\n", H_bitstring);
+    if((verbose == 1) || (verbose == 2)) {
+        if(initial_entropy) {
+            printf("\nH_original: %f\n", H_original);
+            if(data.alph_size > 2) {
+                printf("H_bitstring: %f\n", H_bitstring);
+                printf("min(H_original, %d X H_bitstring): %f\n", data.word_size, min(H_original, data.word_size*H_bitstring));
             }
+        } else {
+            printf("\nh': %f\n", H_bitstring);
         }
-    } else {
+    } else if(verbose > 2) {
         if((data.alph_size > 2) || !initial_entropy) {
             printf("H_bitstring = %.17g\n", H_bitstring);
         }

--- a/cpp/shared/lrs_test.h
+++ b/cpp/shared/lrs_test.h
@@ -196,8 +196,8 @@ void SAalgs(const byte text[], long int n, int k, double &t_tuple_res, double &l
 
 		t_tuple_res = -log2(pu);
 
-		if(verbose == 1) printf("%s t-Tuple Estimate: t = %ld, p-hat_max = %.17g, p_u = %.17g\n", label, u-1, Pmax, pu);
-		else if(verbose == 2) {
+		if(verbose == 2) printf("%s t-Tuple Estimate: t = %ld, p-hat_max = %.17g, p_u = %.17g\n", label, u-1, Pmax, pu);
+		else if(verbose == 3) {
 			printf("%s t-Tuple Estimate: t = %ld\n", label, u-1);
 			printf("%s t-Tuple Estimate: p-hat_max = %.17g\n", label, Pmax);
 			printf("%s t-Tuple Estimate: p_u = %.17g\n", label, pu);
@@ -205,7 +205,7 @@ void SAalgs(const byte text[], long int n, int k, double &t_tuple_res, double &l
 		}
 
 	} else {
-		if(verbose > 0) printf("t-Tuple Estimate: No strings are repeated 35 times. t-Tuple estimate failed.\n");
+		if(verbose > 1) printf("t-Tuple Estimate: No strings are repeated 35 times. t-Tuple estimate failed.\n");
 		t_tuple_res = -1.0;
 	}
 
@@ -271,8 +271,8 @@ void SAalgs(const byte text[], long int n, int k, double &t_tuple_res, double &l
 
 		lrs_res = -log2(pu);
 
-		if(verbose == 1) printf("%s LRS Estimate: u = %ld, v = %ld, p-hat = %.17g, p_u = %.17g\n", label, u, v, Pmax, pu);
-		else if(verbose == 2) {
+		if(verbose == 2) printf("%s LRS Estimate: u = %ld, v = %ld, p-hat = %.17g, p_u = %.17g\n", label, u, v, Pmax, pu);
+		else if(verbose == 3) {
 			printf("%s LRS Estimate: u = %ld\n", label, u);
 			printf("%s LRS Estimate: v = %ld\n", label, v);
 			printf("%s LRS Estimate: p-hat = %.17g\n", label, Pmax);
@@ -339,7 +339,7 @@ bool len_LRS_test(const byte data[], const int L, const int k, const int verbose
 	// It is possible for p_col to be exactly 1 (e.g., if the input data is all one symbol)
 	// In this instance, a collision of any length up to L-1 has probability 1.
 	if(p_col > 1.0L - LDBL_EPSILON) {
-		if(verbose > 0) cout << "\tPr(X >= 1) = 1.0" << endl;
+		if(verbose > 1) cout << "\tPr(X >= 1) = 1.0" << endl;
 		return true;
 	}
 	assert(p_col < 1.0L);
@@ -373,7 +373,7 @@ bool len_LRS_test(const byte data[], const int L, const int k, const int verbose
 	// This is the number of ways of choosing 2 substrings of length W from a string of length L.
 	long int N = n_choose_2(L - W + 1);
 
-	if(verbose > 0){
+	if(verbose > 1){
 		cout << label << "Longest Repeated Substring results" << endl;
 		cout << "\tP_col: " << p_col << endl;
 		cout << "\tLength of LRS: " << W << endl;

--- a/cpp/shared/most_common.h
+++ b/cpp/shared/most_common.h
@@ -25,8 +25,8 @@ double most_common(byte* data, const long len, const int alph_size, const int ve
 
 	ubound = min(1.0,pmax + ZALPHA*sqrt(pmax*(1.0-pmax)/(len-1.0)));
 	entEst = -log2(ubound);
-	if(verbose == 1) printf("%s MCV Estimate: mode = %ld, p-hat = %.17g, p_u = %.17g\n", label, mode, pmax, ubound);
-	else if(verbose == 2) {
+	if(verbose == 2) printf("%s MCV Estimate: mode = %ld, p-hat = %.17g, p_u = %.17g\n", label, mode, pmax, ubound);
+	else if(verbose == 3) {
 		printf("%s Most Common Value Estimate: Mode count = %ld\n", label, mode);
 		printf("%s Most Common Value Estimate: p-hat = %.17g\n", label, pmax);
 		printf("%s Most Common Value Estimate: p_u = %.17g\n", label, ubound);

--- a/cpp/shared/test_case_base.h
+++ b/cpp/shared/test_case_base.h
@@ -3,7 +3,7 @@
 
 #include <cstdlib>
 #include <string>
-#include <jsoncpp/json/json.h>
+#include <json/json.h>
 
 using namespace std;
 

--- a/cpp/shared/test_run_base.h
+++ b/cpp/shared/test_run_base.h
@@ -2,7 +2,7 @@
 #define TESTRUN_H
 
 #include <string>
-#include <jsoncpp/json/json.h>
+#include <json/json.h>
 
 using namespace std;
 

--- a/cpp/shared/utils.h
+++ b/cpp/shared/utils.h
@@ -915,10 +915,10 @@ double predictionEstimate(long C, long N, long max_run_len, long k, const char *
 
 	entEst = -log2(curMax);
 
-	if(verbose == 1) {
+	if(verbose == 2) {
 		if(p_local > 0.0) printf("%s %s Prediction Estimate: N = %ld, Pglobal' = %.17g (C = %ld) Plocal = %.17g (r = %ld)\n", label, testname, N, p_globalPrime, C, p_local, max_run_len+1);
 		else printf("%s %s Prediction Estimate: N = %ld, Pglobal' = %.17g (C = %ld) Plocal can't affect result (r = %ld)\n", label, testname, N, p_globalPrime, C, max_run_len+1);
-	} else if(verbose == 2) {
+	} else if(verbose == 3) {
 		printf("%s %s Prediction Estimate: C = %ld\n", label, testname, C);
 		printf("%s %s Prediction Estimate: r = %ld\n", label, testname, max_run_len + 1);
 		printf("%s %s Prediction Estimate: N = %ld\n", label, testname, N);

--- a/cpp/transpose_main.cpp
+++ b/cpp/transpose_main.cpp
@@ -26,7 +26,7 @@
 
 int main(int argc, char* argv[])
 {
-	int verbose = 0;
+	int verbose = 1;
 	const int r=1000;
 	const int c=1000;
 	int opt;
@@ -65,7 +65,7 @@ int main(int argc, char* argv[])
 		print_usage();
 	}
 
-        if(verbose>0) {
+        if(verbose>1) {
                 if(subsetSize == 0) printf("Opening input file: '%s'\n", argv[0]);
                 else printf("Opening file: '%s', reading block %ld of size %ld\n", argv[0], subsetIndex, subsetSize);
         }
@@ -76,14 +76,14 @@ int main(int argc, char* argv[])
                 print_usage();
         }
 
-	if(verbose > 0) printf("Loaded %ld samples of %d distinct %d-bit-wide symbols\n", data.len, data.alph_size, data.word_size);
+	if(verbose > 1) printf("Loaded %ld samples of %d distinct %d-bit-wide symbols\n", data.len, data.alph_size, data.word_size);
 
 	if(data.len != r*c) {
                 printf("Data must be %d samples.\n", r*c);
                 print_usage();
 	}
 
-	if(verbose>0) printf("Opening output file: '%s'\n", argv[1]);
+	if(verbose>1) printf("Opening output file: '%s'\n", argv[1]);
 	if((fp = fopen(argv[1], "wb"))==NULL) {
 		perror("Can't open output file");
                 print_usage();


### PR DESCRIPTION
 - Resolves string compare issue in `conditioning_main.cpp`. Resolves usnistgov/SP800-90B_EntropyAssessment#186
 - Change meaning of `verbose` flag. Now, `verbose` level `0` is for JSON output, level `1` is the normal mode, level `2` is the NIST tool verbose mode, and level `3` is for extra verbose output.
 - Alter how quietMode works (now it uses `verbose=0`) Resolves usnistgov/SP800-90B_EntropyAssessment#184
 - No longer compares boolean values with `-1`. Resolves usnistgov/SP800-90B_EntropyAssessment#185
 - Caused output of JSON error report when the testing fails in `restart_main.cpp`. Resolves usnistgov/SP800-90B_EntropyAssessment#183