### PR TITLE
Compression overflow

### DIFF
--- a/cpp/iid/chi_square_tests.h
+++ b/cpp/iid/chi_square_tests.h
@@ -648,11 +648,15 @@ bool chi_square_tests(const byte data[], const int sample_size, const int alphab
 	pvalue = chi_square_pvalue(score, df);
 
 	// Print results
-	if(verbose > 1){
+	if(verbose == 2) {
 		printf("Chi square independence\n");
 		printf("\tscore = %f\n", score);
 		printf("\tdegrees of freedom = %d\n", df);
 		printf("\tp-value = %f\n\n", pvalue);
+	} else if(verbose >= 3) {
+		printf("Chi square independence: T = %.17g\n", score);
+		printf("Chi square independence: df = %d\n", df);
+		printf("Chi square independence: P-value = %.17g\n", pvalue);
 	}
 
 	// Check result to return if test failed
@@ -674,11 +678,15 @@ bool chi_square_tests(const byte data[], const int sample_size, const int alphab
 	pvalue = chi_square_pvalue(score, df);
 
 	// Print results
-	if(verbose > 1){
+	if(verbose == 2) {
 		printf("Chi square goodness of fit\n");
 		printf("\tscore = %f\n", score);
 		printf("\tdegrees of freedom = %d\n", df);
 		printf("\tp-value = %f\n\n", pvalue);
+	} else if(verbose >= 3) {
+		printf("Chi square goodness of fit: T = %.17g\n", score);
+		printf("Chi square goodness of fit: df = %d\n", df);
+		printf("Chi square goodness of fit: P-value = %.17g\n", pvalue);
 	}
 
 	// Check result to return if test failed

--- a/cpp/iid/permutation_tests.h
+++ b/cpp/iid/permutation_tests.h
@@ -294,7 +294,7 @@ unsigned int compression(const byte data[], const int sample_size, const byte ma
 	// Build string of bytes
 	// Reserve the necessary size sample_size*(floor(log10(max_symbol))+2)
 	// This is "worst case" and accounts for the space at the end of the number, as well.
-	msg = new char[(size_t)(floor(log10(max_symbol))+2.0)*sample_size];
+	msg = new char[(size_t)(floor(log10(max_symbol))+2.0)*sample_size+1];
 	msg[0] = '\0';
 	curmsg = msg;
 

--- a/cpp/iid/permutation_tests.h
+++ b/cpp/iid/permutation_tests.h
@@ -463,7 +463,7 @@ void run_tests(const data_t *dp, const byte data[], const byte rawdata[], const 
  * ---------------------------------------------
  */
 
-void print_results(int C[][3]){
+void print_results(int C[][3], const int verbose){
 	cout << endl << endl;
 	cout << "                statistic  C[i][0]  C[i][1]  C[i][2]" << endl;
 	cout << "----------------------------------------------------" << endl;
@@ -599,21 +599,25 @@ bool permutation_tests(const data_t *dp, const double rawmean, const double medi
 	}
 
 	// Run initial tests
-	if(verbose > 1) cout << "Beginning initial tests..." << endl;
+	if(verbose == 2) cout << "Beginning initial tests..." << endl;
 	seed(xoshiro256starstarMainSeed);
 
 	run_tests(dp, dp->symbols, dp->rawsymbols, rawmean, median, t, test_status);
 
-	if(verbose > 1){
+	if(verbose == 2) {
 		cout << endl << "Initial test results" << endl;
 		for(unsigned int i = 0; i < num_tests; i++){
 			cout << setw(23) << test_names[i] << ": ";
 			cout << t[i] << endl;
 		}
 		cout << endl;
+	} else if (verbose >= 3) {
+		for(unsigned int i = 0; i < num_tests; i++){
+			printf("Permutation testing: Unpermuted result %s = %.22Lg\n", test_names[i].c_str(), t[i]);
+		}
 	}
 	
-	if(verbose > 1) cout << "Beginning permutation tests... these may take some time" << endl;
+	if(verbose == 2) cout << "Beginning permutation tests... these may take some time" << endl;
 
 	#pragma omp parallel
 	{
@@ -672,7 +676,7 @@ bool permutation_tests(const data_t *dp, const double rawmean, const double medi
 					completed ++;
 				} // end resultUpdate
 
-				if(verbose > 1) {
+				if(verbose == 2) {
 					int res;
 					/* Construct pretty output regardless of whether on terminal (tty) or 
 					* redirected to another file descriptor (eg. redirect to file).
@@ -721,7 +725,7 @@ bool permutation_tests(const data_t *dp, const double rawmean, const double medi
         	delete[](rawdata);
 	} //end parallel
 
-	if(verbose > 1) print_results(C);
+	if(verbose > 1) print_results(C, verbose);
         
     populateTestCase(tc, C);
 	

--- a/cpp/iid_main.cpp
+++ b/cpp/iid_main.cpp
@@ -230,16 +230,20 @@ int main(int argc, char* argv[]) {
     int alphabet_size = data.alph_size;
     int sample_size = data.len;
 
-    if (verbose >= 1)
-        printf("Calculating baseline statistics...\n");
-
+    if ((verbose == 1) || (verbose == 2))
+	   printf("Calculating baseline statistics...\n");
+	
     calc_stats(&data, rawmean, median);
 
-    if (verbose > 1) {
-        printf("\tRaw Mean: %f\n", rawmean);
-        printf("\tMedian: %f\n", median);
-        printf("\tBinary: %s\n\n", (alphabet_size == 2 ? "true" : "false"));
-    }
+	if(verbose == 2) {
+		printf("\tRaw Mean: %f\n", rawmean);
+		printf("\tMedian: %f\n", median);
+		printf("\tBinary: %s\n\n", (alphabet_size == 2 ? "true" : "false"));
+	} else if(verbose > 2) {
+		printf("Raw Mean = %.17g\n", rawmean);
+		printf("Median = %.17g\n", median);
+		printf("Binary = %s\n", (alphabet_size == 2 ? "true" : "false"));
+	}
 
     IidTestCase tc;
     tc.mean = rawmean;
@@ -277,11 +281,12 @@ int main(int argc, char* argv[]) {
         if ((data.alph_size > 2) || !initial_entropy) {
             h_assessed = min(h_assessed, H_bitstring * data.word_size);
             printf("H_bitstring = %.17g\n", H_bitstring);
+            printf("H_bitstring Per Symbol = %.17g\n", H_bitstring * data.word_size);
         }
 
         if (initial_entropy) {
             h_assessed = min(h_assessed, H_original);
-            printf("H_original: %.17g\n", H_original);
+            printf("H_original = %.17g\n", H_original);
         }
 
         printf("Assessed min entropy: %.17g\n", h_assessed);
@@ -292,11 +297,17 @@ int main(int argc, char* argv[]) {
     bool chi_square_test_pass = chi_square_tests(data.symbols, sample_size, alphabet_size, verbose);
     tc.passed_chi_square_tests = chi_square_test_pass;
 
-    if (verbose > 0) {
+    if ((verbose == 1) || (verbose == 2)) {
         if (chi_square_test_pass) {
             printf("** Passed chi square tests\n\n");
         } else {
             printf("** Failed chi square tests\n\n");
+        }
+    } else if(verbose > 2) {
+        if (chi_square_test_pass) {
+            printf("Chi square tests: Passed\n");
+        } else {
+            printf("Chi square tests: Failed\n");
         }
     }
 
@@ -304,11 +315,17 @@ int main(int argc, char* argv[]) {
     bool len_LRS_test_pass = len_LRS_test(data.symbols, sample_size, alphabet_size, verbose, "Literal");
     tc.passed_longest_repeated_substring_test = len_LRS_test_pass;
 
-    if (verbose > 0) {
+    if ((verbose == 1) || (verbose == 2)) {
         if (len_LRS_test_pass) {
             printf("** Passed length of longest repeated substring test\n\n");
         } else {
             printf("** Failed length of longest repeated substring test\n\n");
+        }
+    } else if(verbose > 2) {
+        if (len_LRS_test_pass) {
+            printf("Length of longest repeated substring test: Passed\n");
+        } else {
+            printf("Length of longest repeated substring test: Failed\n");
         }
     }
 
@@ -316,12 +333,18 @@ int main(int argc, char* argv[]) {
     bool perm_test_pass = permutation_tests(&data, rawmean, median, verbose, tc);
     tc.passed_iid_permutation_tests = perm_test_pass;
 
-    if (verbose > 0) {
+    if ((verbose == 1) || (verbose == 2)) {
         if (perm_test_pass) {
             printf("** Passed IID permutation tests\n\n");
         } else {
             printf("** Failed IID permutation tests\n\n");
-        }
+        }        
+    } else if(verbose > 2) {
+        if (perm_test_pass) {
+            printf("IID permutation tests: Passed\n");
+        } else {
+            printf("IID permutation tests: Failed\n");
+        }        
     }
 
     testRun.testCases.push_back(tc);

--- a/cpp/non_iid_main.cpp
+++ b/cpp/non_iid_main.cpp
@@ -480,10 +480,11 @@ int main(int argc, char* argv[]) {
     } else if(verbose > 2) {
         if((data.alph_size > 2) || !initial_entropy) {
             printf("H_bitstring = %.17g\n", H_bitstring);
+            printf("H_bitstring Per Symbol = %.17g\n", H_bitstring * data.word_size);
         }
 
         if (initial_entropy) {
-            printf("H_original: %.17g\n", H_original);
+            printf("H_original = %.17g\n", H_original);
         }
 
         printf("Assessed min entropy: %.17g\n", h_assessed);

--- a/cpp/shared/lrs_test.h
+++ b/cpp/shared/lrs_test.h
@@ -339,7 +339,12 @@ bool len_LRS_test(const byte data[], const int L, const int k, const int verbose
 	// It is possible for p_col to be exactly 1 (e.g., if the input data is all one symbol)
 	// In this instance, a collision of any length up to L-1 has probability 1.
 	if(p_col > 1.0L - LDBL_EPSILON) {
-		if(verbose > 1) cout << "\tPr(X >= 1) = 1.0" << endl;
+		if(verbose == 2) {
+			printf("\tPr(X >= 1) = 1.0\n");
+		} else if(verbose > 2) {
+			printf("%s Longest Repeated Substring: P_col = 1.0\n", label);
+			printf("%s Longest Repeated Substring: Pr(X >= 1) = 1.0\n", label);
+		} 
 		return true;
 	}
 	assert(p_col < 1.0L);
@@ -373,10 +378,15 @@ bool len_LRS_test(const byte data[], const int L, const int k, const int verbose
 	// This is the number of ways of choosing 2 substrings of length W from a string of length L.
 	long int N = n_choose_2(L - W + 1);
 
-	if(verbose > 1){
-		cout << label << "Longest Repeated Substring results" << endl;
-		cout << "\tP_col: " << p_col << endl;
-		cout << "\tLength of LRS: " << W << endl;
+	if(verbose > 1) {
+		if(verbose > 2) {
+			printf("%s Longest Repeated Substring results: P_col = %.22Lg\n", label, p_col);
+			printf("%s Longest Repeated Substring results: W = %d\n", label, W);
+		} else {
+			printf("%s Longest Repeated Substring results\n", label);
+			printf("\tP_col: %Lf\n", p_col);
+			printf("\tLength of LRS: %d\n", W);
+		}
 
 		// Calculate the probability of not encountering a collision after N sets of independent pairs;
 		// this is an application of the Binomial Distribution.
@@ -392,10 +402,10 @@ bool len_LRS_test(const byte data[], const int L, const int k, const int verbose
 		// in this case, this probability isn't accurately representable using the precision that we have to work with, but it is expected to
 		// round reasonably.
 		long double probNoCols = expl(((long double)N)*logProbNoColsPerPair);
-		if((probNoCols <= 1.0L - LDBL_EPSILON) && (probNoCols >= LDBL_EPSILON)) {
-			cout << "\tPr(X >= 1): " << 1.0L - probNoCols << endl;
+		if(verbose > 2) {
+			printf("%s Longest Repeated Substring results: Pr(X >= 1) = %.22Lg\n",  label, 1.0L - probNoCols);
 		} else {
-			cout << "\tPr(X >= 1) rounds to " << 1.0L - probNoCols << ", but there is precision loss. The test verdict is still expected to be valid." << endl;
+			printf("\tPr(X >= 1): %Lf\n", 1.0L - probNoCols);
 		}
 	}
 


### PR DESCRIPTION
This PR resolves the issue reported in #189 and attempts to make the verbose output of `ea_iid` more consistent with the verbose output of `ea_non_iid`.