### PR TITLE
Addressed some bugs introduced in the `sha256_file()` function

### DIFF
--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -7,13 +7,13 @@ ifeq ($(ARCH),x86)
 CXXFLAGS += -msse2 -march=native
 endif
 
-#CXX = clang++-8
-#CXXFLAGS = -Wno-padded -Wno-disabled-macro-expansion -Wno-gnu-statement-expression -Wno-bad-function-cast -fopenmp -O1 -fsanitize=address -fsanitize=undefined -fdenormal-fp-math=ieee -msse2 -march=native
+#CXX = clang++-15
+#CXXFLAGS = -g -Wno-padded -Wno-disabled-macro-expansion -Wno-gnu-statement-expression -Wno-bad-function-cast -fopenmp -O1 -fsanitize=address -fsanitize=undefined -fno-omit-frame-pointer -fdenormal-fp-math=ieee -msse2 -march=native -I/usr/include/jsoncpp
 #static analysis in clang using
-#scan-build-8 --use-c++=/usr/bin/clang++-8 make
+#scan-build-15 --use-c++=/usr/bin/clang++-15 make
 LIB = -lbz2 -lpthread -ldivsufsort 
 COND_LIB = -lmpfr -lgmp
-SHARED_LIB = -ljsoncpp -lssl -lcrypto
+SHARED_LIB = -ljsoncpp -lcrypto
 INC =
 
 ######

--- a/cpp/conditioning_main.cpp
+++ b/cpp/conditioning_main.cpp
@@ -357,6 +357,8 @@ static long double computeEntropyOfConditionedData(string inputfilename, bool ii
 
     data_t data;
     double h_bitstring = 1.0;
+    const int verbose = 0;
+
 
     //Have the code establish the symbol width.
     data.word_size = 0;
@@ -366,51 +368,66 @@ static long double computeEntropyOfConditionedData(string inputfilename, bool ii
 
     if (iid) {
         // IID path
-        h_bitstring = min(h_bitstring, most_common(data.bsymbols, data.blen, 2, true, "Bitstring"));
+        //All of these run the bitstring version of the test (as per SP 800-90B Section 3.1.5.2 Paragraph 2)
+        // Section 6.3.1 - Estimate entropy with Most Common Value
+        h_bitstring = min(h_bitstring, most_common(data.bsymbols, data.blen, 2, verbose, "Bitstring"));
     } else {
         // NON-IID path
         double ret_min_entropy;
         double bin_t_tuple_res = -1.0, bin_lrs_res = -1.0;
 
-        ret_min_entropy = most_common(data.bsymbols, data.blen, 2, true, "Bitstring");
+        //All of these run the bitstring version of the test (as per SP 800-90B Section 3.1.5.2 Paragraph 2)
+        // Section 6.3.1 - Estimate entropy with Most Common Value
+        ret_min_entropy = most_common(data.bsymbols, data.blen, 2, verbose, "Bitstring");
         h_bitstring = min(ret_min_entropy, h_bitstring);
 
-        ret_min_entropy = collision_test(data.bsymbols, data.blen, true, "Bitstring");
+        // Section 6.3.2 - Estimate entropy with Collision Test
+        ret_min_entropy = collision_test(data.bsymbols, data.blen, verbose, "Bitstring");
         h_bitstring = min(ret_min_entropy, h_bitstring);
 
-        ret_min_entropy = markov_test(data.bsymbols, data.blen, true, "Bitstring");
+        // Section 6.3.3 - Estimate entropy with Markov Test
+        ret_min_entropy = markov_test(data.bsymbols, data.blen, verbose, "Bitstring");
         h_bitstring = min(ret_min_entropy, h_bitstring);
 
-        ret_min_entropy = compression_test(data.bsymbols, data.blen, true, "Bitstring");
+        // Section 6.3.4 - Estimate entropy with Compression Test
+        ret_min_entropy = compression_test(data.bsymbols, data.blen, verbose, "Bitstring");
         if (ret_min_entropy >= 0) {
             h_bitstring = min(ret_min_entropy, h_bitstring);
         }
 
-        SAalgs(data.bsymbols, data.blen, 2, bin_t_tuple_res, bin_lrs_res, true, "Bitstring");
+        //This call performs both the t-Tuple Test and the LRS Test
+        SAalgs(data.bsymbols, data.blen, 2, bin_t_tuple_res, bin_lrs_res, verbose, "Bitstring");
+
+        // Section 6.3.5 - Estimate entropy with t-Tuple Test
         if (bin_t_tuple_res >= 0.0) {
             h_bitstring = min(bin_t_tuple_res, h_bitstring);
         }
 
+        // Section 6.3.6 - Estimate entropy with LRS Test
         if (bin_lrs_res >= 0) {
             h_bitstring = min(bin_lrs_res, h_bitstring);
         }
 
-        ret_min_entropy = multi_mcw_test(data.bsymbols, data.blen, 2, true, "Bitstring");
+        // Section 6.3.7 - Estimate entropy with Multi Most Common in Window Test
+        ret_min_entropy = multi_mcw_test(data.bsymbols, data.blen, 2, verbose, "Bitstring");
         if (ret_min_entropy >= 0) {
             h_bitstring = min(ret_min_entropy, h_bitstring);
         }
 
-        ret_min_entropy = lag_test(data.bsymbols, data.blen, 2, true, "Bitstring");
+        // Section 6.3.8 - Estimate entropy with Lag Prediction Test
+        ret_min_entropy = lag_test(data.bsymbols, data.blen, 2, verbose, "Bitstring");
         if (ret_min_entropy >= 0) {
             h_bitstring = min(ret_min_entropy, h_bitstring);
         }
 
-        ret_min_entropy = multi_mmc_test(data.bsymbols, data.blen, 2, true, "Bitstring");
+        // Section 6.3.9 - Estimate entropy with Multi Markov Model with Counting Test (MultiMMC)
+        ret_min_entropy = multi_mmc_test(data.bsymbols, data.blen, 2, verbose, "Bitstring");
         if (ret_min_entropy >= 0) {
             h_bitstring = min(ret_min_entropy, h_bitstring);
         }
 
-        ret_min_entropy = LZ78Y_test(data.bsymbols, data.blen, 2, true, "Bitstring");
+        // Section 6.3.10 - Estimate entropy with LZ78Y Test
+        ret_min_entropy = LZ78Y_test(data.bsymbols, data.blen, 2, verbose, "Bitstring");
         if (ret_min_entropy >= 0) {
             h_bitstring = min(ret_min_entropy, h_bitstring);
         }

--- a/cpp/conditioning_main.cpp
+++ b/cpp/conditioning_main.cpp
@@ -131,6 +131,7 @@ static unsigned int inputUnsignedOption(const char *input, unsigned int low, uns
 static long double calculateEpsilon(mpfr_t calcValue, mpfr_t maxValue, mpfr_prec_t precision) {
     mpfr_t ratio, output, ap_log2;
     mpfr_inits2(precision, ratio, output, ap_log2, NULL);
+    long double value;
 
     // We're going to need an arbitrary precision version of log(2)
     mpfr_set_ui(ap_log2, 2U, MPFR_RNDZ);
@@ -151,13 +152,17 @@ static long double calculateEpsilon(mpfr_t calcValue, mpfr_t maxValue, mpfr_prec
     mpfr_neg(output, output, MPFR_RNDZ);
 
     // return this value
-    return mpfr_get_ld(output, MPFR_RNDZ);
+    value = mpfr_get_ld(output, MPFR_RNDZ);
+    mpfr_clears(ratio, output, ap_log2, NULL);
+
+    return value;
 }
 
 // General goal: want to round to cause psi and omega to be as large as possible (to provide a conservative estimate)
 // If any estimate is not appropriate, increase the precision and start again
 
 static long double computeEntropyWithPrecision(mpfr_prec_t precision, long double h_in, unsigned int n_in, unsigned int n, unsigned int n_out, unsigned int nw, long double &noutEpsilonExp, long double &hinEpsilonExp, long double &nwEpsilonExp) {
+    long double value;
 
     // TODO quietmode?
     printf("Attempting to compute entropy with %ld bits of precision.\n", precision);
@@ -169,6 +174,7 @@ static long double computeEntropyWithPrecision(mpfr_prec_t precision, long doubl
     // Initialize arbitrary precision versions of h_in
     // We want to make sure not to lose precision here.
     if (mpfr_set_ld(ap_h_in, h_in, MPFR_RNDZ) != 0) {
+        mpfr_clears(ap_h_in, ap_entexp, ap_p_high, ap_p_low, ap_denom, ap_inputSpaceSize, ap_diff, ap_power_term, ap_psi, ap_omega, ap_outputEntropy, ap_nw, ap_n_out, NULL);
         return computeEntropyWithPrecision(precision * 2, h_in, n_in, n, n_out, nw, noutEpsilonExp, hinEpsilonExp, nwEpsilonExp);
     }
 
@@ -181,10 +187,12 @@ static long double computeEntropyWithPrecision(mpfr_prec_t precision, long doubl
 
     // p_high must be in the interval (0,1)
     if (mpfr_cmp_ui(ap_p_high, 0UL) <= 0) {
+        mpfr_clears(ap_h_in, ap_entexp, ap_p_high, ap_p_low, ap_denom, ap_inputSpaceSize, ap_diff, ap_power_term, ap_psi, ap_omega, ap_outputEntropy, ap_nw, ap_n_out, NULL);
         return computeEntropyWithPrecision(precision * 2, h_in, n_in, n, n_out, nw, noutEpsilonExp, hinEpsilonExp, nwEpsilonExp);
     }
 
     if (mpfr_cmp_ui(ap_p_high, 1UL) >= 0) {
+        mpfr_clears(ap_h_in, ap_entexp, ap_p_high, ap_p_low, ap_denom, ap_inputSpaceSize, ap_diff, ap_power_term, ap_psi, ap_omega, ap_outputEntropy, ap_nw, ap_n_out, NULL);
         return computeEntropyWithPrecision(precision * 2, h_in, n_in, n, n_out, nw, noutEpsilonExp, hinEpsilonExp, nwEpsilonExp);
     }
 
@@ -194,6 +202,7 @@ static long double computeEntropyWithPrecision(mpfr_prec_t precision, long doubl
     // This is an integer value, and should be exact
     // ap_inputSpaceSize = 2^(n_in)
     if (mpfr_ui_pow_ui(ap_inputSpaceSize, 2UL, n_in, MPFR_RNDZ) != 0) {
+        mpfr_clears(ap_h_in, ap_entexp, ap_p_high, ap_p_low, ap_denom, ap_inputSpaceSize, ap_diff, ap_power_term, ap_psi, ap_omega, ap_outputEntropy, ap_nw, ap_n_out, NULL);
         return computeEntropyWithPrecision(precision * 2, h_in, n_in, n, n_out, nw, noutEpsilonExp, hinEpsilonExp, nwEpsilonExp);
     }
 
@@ -204,6 +213,7 @@ static long double computeEntropyWithPrecision(mpfr_prec_t precision, long doubl
     mpfr_sub(ap_diff, ap_inputSpaceSize, ap_denom, MPFR_RNDZ);
     if (mpfr_cmp_ui(ap_diff, 1UL) != 0) {
         // Evidently not. Increase the precision.
+        mpfr_clears(ap_h_in, ap_entexp, ap_p_high, ap_p_low, ap_denom, ap_inputSpaceSize, ap_diff, ap_power_term, ap_psi, ap_omega, ap_outputEntropy, ap_nw, ap_n_out, NULL);
         return computeEntropyWithPrecision(precision * 2, h_in, n_in, n, n_out, nw, noutEpsilonExp, hinEpsilonExp, nwEpsilonExp);
     }
 
@@ -212,10 +222,12 @@ static long double computeEntropyWithPrecision(mpfr_prec_t precision, long doubl
 
     // p_low must be in the interval (0,1)
     if (mpfr_cmp_ui(ap_p_low, 0UL) <= 0) {
+        mpfr_clears(ap_h_in, ap_entexp, ap_p_high, ap_p_low, ap_denom, ap_inputSpaceSize, ap_diff, ap_power_term, ap_psi, ap_omega, ap_outputEntropy, ap_nw, ap_n_out, NULL);
         return computeEntropyWithPrecision(precision * 2, h_in, n_in, n, n_out, nw, noutEpsilonExp, hinEpsilonExp, nwEpsilonExp);
     }
 
     if (mpfr_cmp_ui(ap_p_low, 1UL) >= 0) {
+        mpfr_clears(ap_h_in, ap_entexp, ap_p_high, ap_p_low, ap_denom, ap_inputSpaceSize, ap_diff, ap_power_term, ap_psi, ap_omega, ap_outputEntropy, ap_nw, ap_n_out, NULL);
         return computeEntropyWithPrecision(precision * 2, h_in, n_in, n, n_out, nw, noutEpsilonExp, hinEpsilonExp, nwEpsilonExp);
     }
 
@@ -223,6 +235,7 @@ static long double computeEntropyWithPrecision(mpfr_prec_t precision, long doubl
     // This is an integer value, and should be exact
     // power_term = 2^(n_in - n)
     if (mpfr_ui_pow_ui(ap_power_term, 2UL, n_in - n, MPFR_RNDU) != 0) {
+        mpfr_clears(ap_h_in, ap_entexp, ap_p_high, ap_p_low, ap_denom, ap_inputSpaceSize, ap_diff, ap_power_term, ap_psi, ap_omega, ap_outputEntropy, ap_nw, ap_n_out, NULL);
         return computeEntropyWithPrecision(precision * 2, h_in, n_in, n, n_out, nw, noutEpsilonExp, hinEpsilonExp, nwEpsilonExp);
     }
 
@@ -235,6 +248,7 @@ static long double computeEntropyWithPrecision(mpfr_prec_t precision, long doubl
 
     // h_in > 0 so Psi > P_high. If this isn't so, then we're doing the calculation at too low of a precision.
     if (mpfr_cmp(ap_p_high, ap_psi) >= 0) {
+        mpfr_clears(ap_h_in, ap_entexp, ap_p_high, ap_p_low, ap_denom, ap_inputSpaceSize, ap_diff, ap_power_term, ap_psi, ap_omega, ap_outputEntropy, ap_nw, ap_n_out, NULL);
         return computeEntropyWithPrecision(precision * 2, h_in, n_in, n, n_out, nw, noutEpsilonExp, hinEpsilonExp, nwEpsilonExp);
     }
 
@@ -243,6 +257,7 @@ static long double computeEntropyWithPrecision(mpfr_prec_t precision, long doubl
 
     // If we have equality, then we didn't use adaquate precision.
     if (mpfr_cmp_ui(ap_psi, 0UL) == 0) {
+        mpfr_clears(ap_h_in, ap_entexp, ap_p_high, ap_p_low, ap_denom, ap_inputSpaceSize, ap_diff, ap_power_term, ap_psi, ap_omega, ap_outputEntropy, ap_nw, ap_n_out, NULL);
         return computeEntropyWithPrecision(precision * 2, h_in, n_in, n, n_out, nw, noutEpsilonExp, hinEpsilonExp, nwEpsilonExp);
     }
 
@@ -256,6 +271,7 @@ static long double computeEntropyWithPrecision(mpfr_prec_t precision, long doubl
     // We're going to need an arbitrary precision version of log(2)
     // omega = 2
     if (mpfr_set_ui(ap_omega, 2U, MPFR_RNDZ) != 0) {
+        mpfr_clears(ap_h_in, ap_entexp, ap_p_high, ap_p_low, ap_denom, ap_inputSpaceSize, ap_diff, ap_power_term, ap_psi, ap_omega, ap_outputEntropy, ap_nw, ap_n_out, NULL);
         return computeEntropyWithPrecision(precision * 2, h_in, n_in, n, n_out, nw, noutEpsilonExp, hinEpsilonExp, nwEpsilonExp);
     }
 
@@ -276,6 +292,7 @@ static long double computeEntropyWithPrecision(mpfr_prec_t precision, long doubl
 
     if (mpfr_cmp_ui(ap_omega, 0UL) == 0) {
         // Omega is expected to be non-zero for all parameters
+        mpfr_clears(ap_h_in, ap_entexp, ap_p_high, ap_p_low, ap_denom, ap_inputSpaceSize, ap_diff, ap_power_term, ap_psi, ap_omega, ap_outputEntropy, ap_nw, ap_n_out, NULL);
         return computeEntropyWithPrecision(precision * 2, h_in, n_in, n, n_out, nw, noutEpsilonExp, hinEpsilonExp, nwEpsilonExp);
     }
 
@@ -302,11 +319,13 @@ static long double computeEntropyWithPrecision(mpfr_prec_t precision, long doubl
     // Could outputEntropy be valid?
     // We know that n_out > ap_outputEntropy for all finite inputs...
     if (mpfr_cmp_ui(ap_outputEntropy, n_out) >= 0) {
+        mpfr_clears(ap_h_in, ap_entexp, ap_p_high, ap_p_low, ap_denom, ap_inputSpaceSize, ap_diff, ap_power_term, ap_psi, ap_omega, ap_outputEntropy, ap_nw, ap_n_out, NULL);
         return computeEntropyWithPrecision(precision * 2, h_in, n_in, n, n_out, nw, noutEpsilonExp, hinEpsilonExp, nwEpsilonExp);
     }
 
     //We know that h_in > ap_outputEntropy for all finite inputs...
     if (mpfr_cmp(ap_outputEntropy, ap_h_in) >= 0) {
+        mpfr_clears(ap_h_in, ap_entexp, ap_p_high, ap_p_low, ap_denom, ap_inputSpaceSize, ap_diff, ap_power_term, ap_psi, ap_omega, ap_outputEntropy, ap_nw, ap_n_out, NULL);
         return computeEntropyWithPrecision(precision * 2, h_in, n_in, n, n_out, nw, noutEpsilonExp, hinEpsilonExp, nwEpsilonExp);
     }
 
@@ -326,101 +345,80 @@ static long double computeEntropyWithPrecision(mpfr_prec_t precision, long doubl
     // If we get here, then adequate precision was used
     // Extract a value for display.
     // Note, this may round up, but we'll deal with this later.
-    return mpfr_get_ld(ap_outputEntropy, MPFR_RNDN);
+    value =  mpfr_get_ld(ap_outputEntropy, MPFR_RNDN);
+    mpfr_clears(ap_h_in, ap_entexp, ap_p_high, ap_p_low, ap_denom, ap_inputSpaceSize, ap_diff, ap_power_term, ap_psi, ap_omega, ap_outputEntropy, ap_nw, ap_n_out, NULL);
+
+    return value;
 }
 
+//This function performs statistical testing on the bitwise input data.
+//It returns h', which is a value in the range [0,1].
 static long double computeEntropyOfConditionedData(string inputfilename, bool iid) {
 
     data_t data;
+    double h_bitstring = 1.0;
+
+    //Have the code establish the symbol width.
     data.word_size = 0;
 
-    read_file_subset(inputfilename.c_str(), &data, ULONG_MAX, 0);
-
-    double h_bitstring = 1.0;
-    double h_assessed = data.word_size;
-    double h_original = data.word_size;
-    int sample_size = data.len;
-    int alphabet_size = data.alph_size;
+    //Read in the complete file.
+    read_file_subset(inputfilename.c_str(), &data, 0, 0);
 
     if (iid) {
         // IID path
-        if (data.alph_size > 2) {
-            h_bitstring = most_common(data.bsymbols, data.blen, 2, false, "Bitstring");
-            h_assessed = min(h_assessed, h_bitstring * data.word_size);
-        }
-
-        h_assessed = min(h_assessed, h_bitstring * data.word_size);
-        h_original = most_common(data.symbols, sample_size, alphabet_size, false, "Literal");
-        h_assessed = min(h_assessed, h_original);
-
-        if (h_assessed != 0) {
-            h_assessed = h_assessed / data.word_size;
-        }
+        h_bitstring = min(h_bitstring, most_common(data.bsymbols, data.blen, 2, true, "Bitstring"));
     } else {
-
         // NON-IID path
-        h_assessed = data.word_size;
-        double ret_min_entropy = 0.0;
+        double ret_min_entropy;
         double bin_t_tuple_res = -1.0, bin_lrs_res = -1.0;
 
-        if (data.alph_size > 2) {
+        ret_min_entropy = most_common(data.bsymbols, data.blen, 2, true, "Bitstring");
+        h_bitstring = min(ret_min_entropy, h_bitstring);
 
-            ret_min_entropy = most_common(data.bsymbols, data.blen, 2, false, "Bitstring");
+        ret_min_entropy = collision_test(data.bsymbols, data.blen, true, "Bitstring");
+        h_bitstring = min(ret_min_entropy, h_bitstring);
+
+        ret_min_entropy = markov_test(data.bsymbols, data.blen, true, "Bitstring");
+        h_bitstring = min(ret_min_entropy, h_bitstring);
+
+        ret_min_entropy = compression_test(data.bsymbols, data.blen, true, "Bitstring");
+        if (ret_min_entropy >= 0) {
             h_bitstring = min(ret_min_entropy, h_bitstring);
-
-            ret_min_entropy = collision_test(data.bsymbols, data.blen, false, "Bitstring");
-            h_bitstring = min(ret_min_entropy, h_bitstring);
-
-            ret_min_entropy = markov_test(data.bsymbols, data.blen, false, "Bitstring");
-            h_bitstring = min(ret_min_entropy, h_bitstring);
-
-            ret_min_entropy = compression_test(data.bsymbols, data.blen, false, "Bitstring");
-            if (ret_min_entropy >= 0) {
-                h_bitstring = min(ret_min_entropy, h_bitstring);
-            }
-
-            SAalgs(data.bsymbols, data.blen, 2, bin_t_tuple_res, bin_lrs_res, false, "Bitstring");
-            if (bin_t_tuple_res >= 0.0) {
-                h_bitstring = min(bin_t_tuple_res, h_bitstring);
-            }
-
-            if (bin_lrs_res >= 0) {
-                h_bitstring = min(bin_lrs_res, h_bitstring);
-            }
-
-            ret_min_entropy = multi_mcw_test(data.bsymbols, data.blen, 2, false, "Bitstring");
-            if (ret_min_entropy >= 0) {
-                h_bitstring = min(ret_min_entropy, h_bitstring);
-            }
-
-            ret_min_entropy = lag_test(data.bsymbols, data.blen, 2, false, "Bitstring");
-            if (ret_min_entropy >= 0) {
-                h_bitstring = min(ret_min_entropy, h_bitstring);
-            }
-
-            ret_min_entropy = multi_mmc_test(data.bsymbols, data.blen, 2, false, "Bitstring");
-            if (ret_min_entropy >= 0) {
-                h_bitstring = min(ret_min_entropy, h_bitstring);
-            }
-
-            ret_min_entropy = LZ78Y_test(data.bsymbols, data.blen, 2, false, "Bitstring");
-            if (ret_min_entropy >= 0) {
-                h_bitstring = min(ret_min_entropy, h_bitstring);
-            }
         }
 
-        h_assessed = data.word_size;
-
-        if (data.alph_size > 2) {
-            h_assessed = min(h_assessed, h_bitstring * data.word_size);
+        SAalgs(data.bsymbols, data.blen, 2, bin_t_tuple_res, bin_lrs_res, true, "Bitstring");
+        if (bin_t_tuple_res >= 0.0) {
+            h_bitstring = min(bin_t_tuple_res, h_bitstring);
         }
 
-        if (h_assessed != 0) {
-            h_assessed = h_assessed / data.word_size;
+        if (bin_lrs_res >= 0) {
+            h_bitstring = min(bin_lrs_res, h_bitstring);
+        }
+
+        ret_min_entropy = multi_mcw_test(data.bsymbols, data.blen, 2, true, "Bitstring");
+        if (ret_min_entropy >= 0) {
+            h_bitstring = min(ret_min_entropy, h_bitstring);
+        }
+
+        ret_min_entropy = lag_test(data.bsymbols, data.blen, 2, true, "Bitstring");
+        if (ret_min_entropy >= 0) {
+            h_bitstring = min(ret_min_entropy, h_bitstring);
+        }
+
+        ret_min_entropy = multi_mmc_test(data.bsymbols, data.blen, 2, true, "Bitstring");
+        if (ret_min_entropy >= 0) {
+            h_bitstring = min(ret_min_entropy, h_bitstring);
+        }
+
+        ret_min_entropy = LZ78Y_test(data.bsymbols, data.blen, 2, true, "Bitstring");
+        if (ret_min_entropy >= 0) {
+            h_bitstring = min(ret_min_entropy, h_bitstring);
         }
     }
 
-    return h_assessed;
+    free_data(&data);
+
+    return h_bitstring;
 }
 
 int main(int argc, char* argv[]) {

--- a/cpp/iid_main.cpp
+++ b/cpp/iid_main.cpp
@@ -8,6 +8,7 @@
 #include "shared/TestRunUtils.h"
 #include "iid/permutation_tests.h"
 #include "iid/chi_square_tests.h"
+#include <openssl/sha.h>
 #include <omp.h>
 #include <getopt.h>
 #include <limits.h>
@@ -192,18 +193,18 @@ int main(int argc, char* argv[]) {
         }
     }
 
-    if (verbose > 1) {
-        if (subsetSize == 0) {
-            printf("Opening file: '%s'\n", file_path);
-        } else {
-            printf("Opening file: '%s', reading block %ld of size %ld\n", file_path, subsetIndex, subsetSize);
-        }
-    }
-
     // Record hash of input file
-    char hash[65];
+    char hash[2*SHA256_DIGEST_LENGTH+1];
     sha256_file(file_path, hash);
     testRun.sha256 = hash;
+
+    if (verbose > 1) {
+        if (subsetSize == 0) {
+            printf("Opening file: '%s' (SHA-256 hash %s)\n", file_path, hash);
+        } else {
+            printf("Opening file: '%s' (SHA-256 hash %s), reading block %ld of size %ld\n", file_path, hash, subsetIndex, subsetSize);
+        }
+    }
 
     if (!read_file_subset(file_path, &data, subsetIndex, subsetSize)) {
 

--- a/cpp/non_iid_main.cpp
+++ b/cpp/non_iid_main.cpp
@@ -17,6 +17,7 @@
 #include <limits.h>
 #include <iostream>
 #include <fstream>
+#include <openssl/sha.h>
 
 [[ noreturn ]] void print_usage() {
     printf("Usage is: ea_non_iid [-i|-c] [-a|-t] [-v] [-q] [-l <index>,<samples> ] <file_name> [bits_per_symbol]\n\n");
@@ -174,7 +175,7 @@ int main(int argc, char* argv[]) {
     // get filename
     file_path = argv[0];
 
-    char hash[65];
+    char hash[2*SHA256_DIGEST_LENGTH+1];
     sha256_file(file_path, hash);
 
     testRun.sha256 = hash;
@@ -203,8 +204,8 @@ int main(int argc, char* argv[]) {
     }
 
     if (verbose > 1) {
-        if (subsetSize == 0) printf("Opening file: '%s'\n", file_path);
-        else printf("Opening file: '%s', reading block %ld of size %ld\n", file_path, subsetIndex, subsetSize);
+        if (subsetSize == 0) printf("Opening file: '%s' (SHA-256 hash %s)\n", file_path, hash);
+        else printf("Opening file: '%s' (SHA-256 hash %s), reading block %ld of size %ld\n", file_path, hash, subsetIndex, subsetSize);
     }
 
     if (!read_file_subset(file_path, &data, subsetIndex, subsetSize)) {

--- a/cpp/restart_main.cpp
+++ b/cpp/restart_main.cpp
@@ -18,6 +18,7 @@
 #include <limits.h>
 #include <iostream>
 #include <fstream>
+#include <openssl/sha.h>
 
 //Each test has a targeted chance of roughly 0.000005, and we need to witness at least 5 failures, so this should be no less than 1000000
 #define SIMULATION_ROUNDS 5000000
@@ -203,7 +204,7 @@ int main(int argc, char* argv[]) {
 
     if (quietMode) verbose = 0;
 
-    char hash[65];
+    char hash[2*SHA256_DIGEST_LENGTH+1];
     sha256_file(file_path, hash);
 
     IidTestRun testRunIid;
@@ -274,7 +275,7 @@ int main(int argc, char* argv[]) {
         print_usage();
     }
 
-    if (verbose > 1) printf("Opening file: '%s'\n", file_path);
+    if (verbose > 1) printf("Opening file: '%s' (SHA-256 hash %s)\n", file_path, hash);
 
     if (!read_file(file_path, &data)) {
         printf("Error reading file.\n");

--- a/cpp/shared/TestRunUtils.h
+++ b/cpp/shared/TestRunUtils.h
@@ -62,65 +62,48 @@ void sha256_hash_string(unsigned char hash[SHA256_DIGEST_LENGTH], char outputBuf
     outputBuffer[64] = 0;
 }
 
-/* Removed deprecated SHA256 generation 11/17/2022
-void sha256_string(char *string, char outputBuffer[65])
-{
-    unsigned char hash[SHA256_DIGEST_LENGTH];
-    SHA256_CTX sha256;
-    SHA256_Init(&sha256);
-    SHA256_Update(&sha256, string, strlen(string));
-    SHA256_Final(hash, &sha256);
-    int i = 0;
-    for(i = 0; i < SHA256_DIGEST_LENGTH; i++)
-    {
-        sprintf(outputBuffer + (i * 2), "%02x", hash[i]);
-    }
-    outputBuffer[64] = 0;
-}
- */
 int sha256_file(char *path, char outputBuffer[65]) {
     
-    unsigned const char *buffer;
-    unsigned long fileLength;
+    unsigned char *buffer;
+    unsigned long fileLen;
     unsigned char digest[SHA256_DIGEST_LENGTH];
-    
+    int i;
+
+    /*open the file*/
     FILE *file = fopen(path, "rb");
     if (!file) return -1;
 
-    /*Removed deprecated SHA256 generation 11/17/2022
-        unsigned char hash[SHA256_DIGEST_LENGTH];
-        SHA256_CTX sha256;
-        SHA256_Init(&sha256);
-        const int bufSize = 32768;
-        unsigned char *buffer = (unsigned char*) malloc(bufSize);
-        int bytesRead = 0;
-        if(!buffer) return ENOMEM;
-        while((bytesRead = fread(buffer, 1, bufSize, file)))
-        {
-            SHA256_Update(&sha256, buffer, bytesRead);
-        }
-        SHA256_Final(hash, &sha256);
-     */
-
-    
+    /* Get the file length */ 
     fseek(file, 0, SEEK_END);
     fileLen = ftell(file);
     fseek(file, 0, SEEK_SET);
 
-    buffer = (unsigned const char *) malloc(fileLen + 1);
+    /* Allocate the buffer */
+    buffer = new unsigned char[fileLen];
     if (!buffer) {
         fprintf(stderr, "Out of memory error!");
         fclose(file);
-        return 0;
+        return -1;
     }
-    int i;
-    i = fread((char *) buffer, fileLength, 1, file);
+
+    /* Read in the data to the buffer. */
+    if((i = fread(buffer, fileLen, 1, file))!=1) {
+        fprintf(stderr, "Can't read the input data\n");
+        fclose(file);
+        return -1;
+    };
+
+    /* Close the file. */
     fclose(file);
 
+    /* Calculate the hash. */
     SHA256(buffer, fileLen, (unsigned char*) &digest);
 
+    /* Output the hash as a string. */
     sha256_hash_string(digest, outputBuffer);
-    fclose(file);
+
+   /* De-allocate the buffer. */
+    delete[] buffer;
 
     return 0;
 }


### PR DESCRIPTION
These bugs were introduced in 43f759db4751655ecc0f3d995ccbae9d6d5ff4e3

There were a few issues:
* The existing code didn't compile because the code used both `fileLength` and `fileLen` to mean the same thing. This PR includes the fix proposed by @Zalamar in usnistgov/SP800-90B_EntropyAssessment#202
* `const` was used incorrectly; `buffer` was declared to be a pointer to a constant region, which then was changed. In this case, the pointer is fixed, but the value being pointed to is changed.
* A memory leak is introduced; the code used malloc to allocate memory, but the free call isn't ever used (or available, without adding additional headers) and the buffer pointer is not available outside this function. This PR uses the C++ new/delete operators instead.
* The `buffer` array was larger than it needed to be. (This buffer is not a c string, so there is no trailing null character).
* Errors were not consistently flagged. (Several errors resulted in a return code of 0, indicating success...)
* There was no error checking on the file read.
* There was a double free due to two different fclose() calls.
* Old code was left in place. Version tracking generally removes the need for this sort of thing. I removed these block comments.
* There was no newline present on the last line of the file.

I propose that future changes be compiled and run on data at least once prior to checking in the code, particularly when the code is going into the master branch.

Resolves usnistgov/SP800-90B_EntropyAssessment#203
Resolves usnistgov/SP800-90B_EntropyAssessment#205
Resolves usnistgov/SP800-90B_EntropyAssessment#206
Resolves usnistgov/SP800-90B_EntropyAssessment#210
Resolves usnistgov/SP800-90B_EntropyAssessment#211