### PR TITLE
Make "Full Entropy" report consistent with IG D.K Resolution 19

### DIFF
--- a/cpp/shared/TestRunUtils.h
+++ b/cpp/shared/TestRunUtils.h
@@ -59,7 +59,7 @@ void sha256_hash_string(unsigned char *hash, char *outputBuffer) {
     }
 }
 
-int sha256_file(char *path, char *outputBuffer) {
+int sha256_file(const char *path, char *outputBuffer) {
     unsigned char *buffer=NULL;
     unsigned char digest[SHA256_DIGEST_LENGTH];
     size_t bytesRead;


### PR DESCRIPTION
The older "draft" definitions of "full entropy" aren't very relevant now that the term is defined in IG D.K. Revise the output to be consistent with this criterion.

Also did some small code cleanup to remove superfluous variables.