### PR TITLE
Consistently run both the chi-square independence and chi-square goodness-of-fit tests

### DIFF
--- a/cpp/iid/chi_square_tests.h
+++ b/cpp/iid/chi_square_tests.h
@@ -637,6 +637,7 @@ bool chi_square_tests(const uint8_t data[], const int sample_size, const int alp
 	double score = 0.0;
 	double pvalue;
 	int df = 0;
+	bool result = true;
 
 	// Chi Square independence test
 	if(alphabet_size == 2){
@@ -661,7 +662,7 @@ bool chi_square_tests(const uint8_t data[], const int sample_size, const int alp
 
 	// Check result to return if test failed
 	if(pvalue < 0.001){
-		return false;
+		result = false;
 	}
 
 	// Reset score and df
@@ -691,8 +692,8 @@ bool chi_square_tests(const uint8_t data[], const int sample_size, const int alp
 
 	// Check result to return if test failed
 	if(pvalue < 0.001){
-		return false;
+		result = false;
 	}
 
-	return true;
+	return result;
 }


### PR DESCRIPTION
For large-scale (i.e., multi-block) IID testing, it is useful to know the results of all 22 of the tests specified in SP 800-90B Section 5. In the existing code, the two chi-square tests are conceptualized as a single test, and if the first one (independence) fails, the second chi-square test isn't run. This is fine when viewing the test in isolation, but in the instance where the tester is tracking the results of each of the tests, this is troublesome.

This small PR prevents this short-circuiting, and always runs both chi-square tests.