### PR TITLE
PE-2407 Update the IID Permutation Test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ ea_transpose
 *.json
 .DS_Store
 *.res
+.gitignore
+cpp/Makefile

--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -2,7 +2,7 @@ ARCH ?= x86
 
 CXX ?= $(CROSS_COMPILE)g++
 
-CXXFLAGS = -std=c++11 -fopenmp -O2 -ffloat-store -I/usr/include/jsoncpp
+CXXFLAGS = -std=c++11 -fopenmp -O2 -ffloat-store -I/opt/homebrew/include -L/opt/homebrew/lib
 ifeq ($(ARCH),x86)
 CXXFLAGS += -march=native
 endif

--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -2,7 +2,7 @@ ARCH ?= x86
 
 CXX ?= $(CROSS_COMPILE)g++
 
-CXXFLAGS = -std=c++11 -fopenmp -O2 -ffloat-store -I/opt/homebrew/include -L/opt/homebrew/lib
+CXXFLAGS = -std=c++11 -fopenmp -O2 -ffloat-store -I/usr/include/jsoncpp
 ifeq ($(ARCH),x86)
 CXXFLAGS += -march=native
 endif

--- a/cpp/iid/iid_test_case.h
+++ b/cpp/iid/iid_test_case.h
@@ -25,6 +25,7 @@ public:
     double h_i = -1.0;
 
     vector<PermutationTestResult> testResults;
+    std::vector<double> p_values; // Stores permutation test p-values
 
     Json::Value GetAsJson() {
         Json::Value json = TestCaseBase::GetBaseJson();
@@ -50,6 +51,13 @@ public:
         for (int i = 0; i < (int)testResults.size(); i++) {
             permutationTestResults[i] = testResults[i].GetAsJson();
         }
+
+        // Add permutationPValues array
+        Json::Value pValueArray;
+        for (size_t i = 0; i < p_values.size(); ++i) {
+            pValueArray[Json::ArrayIndex(i)] = p_values[i];
+        }
+        json["permutationPValues"] = pValueArray;
 
         json["permutationTestResults"] = permutationTestResults;
 

--- a/cpp/iid/permutation_tests.h
+++ b/cpp/iid/permutation_tests.h
@@ -598,7 +598,7 @@ bool permutation_tests(const data_t *dp, const double rawmean, const double medi
 	// To store p-values
 	std::vector<double> p_values(num_tests, 0.0);
 
-	istty = (isatty(STDOUT_FILENO)==1);
+	istty = (isatty(fileno(stderr)) == 1);
 
 	// Build map of results
 	for(unsigned int i = 0; i < num_tests; ++i){

--- a/cpp/iid/permutation_tests.h
+++ b/cpp/iid/permutation_tests.h
@@ -6,12 +6,17 @@
 #include "../shared/TestCase.h"
 #include <assert.h>
 #include <unistd.h>
+#include <vector>
+#include <iomanip>
 
 // The tests used
 const unsigned int num_tests = 19;
 const string test_names[] = {"excursion","numDirectionalRuns","lenDirectionalRuns","numIncreasesDecreases","numRunsMedian","lenRunsMedian","avgCollision","maxCollision","periodicity(1)","periodicity(2)","periodicity(8)","periodicity(16)","periodicity(32)","covariance(1)","covariance(2)","covariance(8)","covariance(16)","covariance(32)","compression"};
 
 using namespace std;
+
+const int LOW_THRESH = (int)(0.01/2 * PERMS);  // 50 when PERMS = 10000
+const int HIGH_THRESH = PERMS - LOW_THRESH;     // 9950
 
 /*
  * ---------------------------------------------
@@ -585,6 +590,8 @@ bool permutation_tests(const data_t *dp, const double rawmean, const double medi
 	// Original test results (t) 
 	long double t[num_tests];
 	bool test_status[num_tests];
+	// To store p-values
+	std::vector<double> p_values(num_tests, 0.0);
 
 	istty = (isatty(STDOUT_FILENO)==1);
 
@@ -625,7 +632,6 @@ bool permutation_tests(const data_t *dp, const double rawmean, const double medi
 		uint8_t *rawdata;
 		uint64_t xoshiro256starstarSeed[4];
 		long double tp[num_tests];
-		int passed_count;
 
 		data = new uint8_t[dp->len];
 		rawdata = new uint8_t[dp->len];
@@ -640,50 +646,37 @@ bool permutation_tests(const data_t *dp, const double rawmean, const double medi
 			rawdata[i] = dp->rawsymbols[i];
 		}
 
-		passed_count = 0;
 		memcpy(xoshiro256starstarSeed, xoshiro256starstarMainSeed, sizeof(xoshiro256starstarMainSeed));
 		//Cause the RNG to jump omp_get_thread_num() * 2^128 calls
 		xoshiro_jump(omp_get_thread_num(), xoshiro256starstarSeed);
 
 		#pragma omp for
 		for(int i = 0; i < PERMS; ++i) {
-			if(passed_count < 19) {
+			{
 				char statusMessage[1024];
 				size_t statusMessageLength = 0;
 
 				FYshuffle(data, rawdata, dp->len, xoshiro256starstarSeed);
 				run_tests(dp, data, rawdata, rawmean, median, tp, test_status);
 
-				// Aggregate results into the counters
 				#pragma omp critical(resultUpdate)
 				{
 					for(unsigned int j = 0; j < num_tests; ++j){
 						if(test_status[j]) {
-							if(tp[j] > t[j]){
+							if (tp[j] < t[j]) {
 								C[j][0]++;
-							} else if(tp[j] == t[j]){
+							} else if (tp[j] == t[j]) {
 								C[j][1]++;
 							} else {
 								C[j][2]++;
 							}
-							if((C[j][0] + C[j][1] > 5) && (C[j][1] + C[j][2] > 5)) {
-								test_status[j] = false;
-							}
 						}
 					}
-					passed_count = 0;
-					for(unsigned int j=0; j < num_tests; j++) if(!test_status[j]) passed_count++;
-					completed ++;
-				} // end resultUpdate
+					completed++;
+				}
 
 				if(verbose == 2) {
 					int res;
-					/* Construct pretty output regardless of whether on terminal (tty) or 
-					* redirected to another file descriptor (eg. redirect to file).
-					* Note that if using something like 'tee' to replicate the output
-					* then it might be handy to use 'unbuffer' to fake the call into
-					* thinking it is still being sent to a tty.
-					*/
 					if(istty) {
 						statusMessage[0] = '\r';
 						statusMessage[1] = '\0';
@@ -693,47 +686,48 @@ bool permutation_tests(const data_t *dp, const double rawmean, const double medi
 						statusMessageLength = 0;
 					}
 
-					res = snprintf(statusMessage+statusMessageLength, sizeof(statusMessage)-statusMessageLength, "%6.02f%% of Permutation test rounds, %6.02f%% of Permutation tests", (100.0*((float)completed)/((float)PERMS)), (100.0*((float)passed_count)/19.0));
+					res = snprintf(statusMessage+statusMessageLength, sizeof(statusMessage)-statusMessageLength,
+								   "\n %6.02f%% of Permutation test rounds", (100.0*((float)completed)/((float)PERMS)));
 					assert(res>0);
 					statusMessageLength += res;
 					assert(statusMessageLength < sizeof(statusMessage));
 
-					/* If not displaying to screen, then we can print even more information. Ultimately
-					* we want the '\n' however printed when not printing to terminal so that the redirected
-					* output looks nicer. 
-					*/
-					if(!istty)  {
-						res = snprintf(statusMessage+statusMessageLength, sizeof(statusMessage)-statusMessageLength, " (Core %d/%d, passed_count %d)\n", omp_get_thread_num(), omp_get_num_threads()-1, passed_count);
-						assert(res>0);
-						statusMessageLength += res;
-						assert(statusMessageLength < sizeof(statusMessage));
-					}
 					#pragma omp critical(verboseOutput)
 					{
 						fputs(statusMessage, stdout);
 						fflush(stdout);
 					}
 				}
-			} else {
-				//We don't have a lock for this branch, so make one to update the completed count.
-				#pragma omp atomic
-				completed ++;
 			}
-
 		}
-        	delete[](data);
-        	delete[](rawdata);
+		delete[](data);
+		delete[](rawdata);
 	} //end parallel
 
 	if(verbose > 1) print_results(C, verbose);
-        
-    populateTestCase(tc, C);
-	
-    for(unsigned int i = 0; i < num_tests; ++i){
-		if((C[i][0] + C[i][1] <= 5) || (C[i][1] + C[i][2] <= 5)){
-			return false;
-	 	}
-	}
 
-	return true;
+    populateTestCase(tc, C);
+	 tc.passed_iid_permutation_tests = true;
+		for (unsigned int i = 0; i < num_tests; ++i) {
+			if ((C[i][0] + C[i][1] <= 5) || (C[i][1] + C[i][2] <= 5)) {
+				tc.passed_iid_permutation_tests = false;
+				break;
+			}
+		}
+
+    if (verbose >= 1) {
+        std::cout << "\n=== Permutation Test P-values ===" << std::endl;
+    }
+    tc.p_values.clear();
+    for (unsigned int i = 0; i < num_tests; ++i) {
+        int total = C[i][0] + C[i][1] + C[i][2];
+        double p = (C[i][2] + 0.5 * C[i][1]) / total;
+        p_values[i] = p;
+        tc.p_values.push_back(p);
+        if (verbose >= 1) {
+            std::cout << "    " << std::setw(23) << test_names[i]
+                      << "  P-value: " << std::fixed << std::setprecision(6) << p << std::endl;
+        }
+    }
+    return true;
 }

--- a/cpp/iid/permutation_tests.h
+++ b/cpp/iid/permutation_tests.h
@@ -647,9 +647,6 @@ bool permutation_tests(const data_t *dp, const double rawmean, const double medi
 	
 	if(verbose == 2) cout << "Beginning permutation tests... these may take some time" << endl;
 	if(verbose >= 1) std::cout << std::endl;
-	if (istty && verbose >= 1) {
-	    *status_stream << "\n[----------] 0/" << PERMS << " - 0.00% of total permutation complete...\nElapsed: 0s\nETA (HH:MM:SS): 00:00:00" << std::flush;
-	}
 
 	// Progress tracking for all permutations
 	std::atomic<size_t> completed{0};

--- a/cpp/iid/permutation_tests.h
+++ b/cpp/iid/permutation_tests.h
@@ -697,7 +697,7 @@ bool permutation_tests(const data_t *dp, const double rawmean, const double medi
     populateTestCase(tc, C);
 	 tc.passed_iid_permutation_tests = true;
 		for (unsigned int i = 0; i < num_tests; ++i) {
-			if ((C[i][0] + C[i][1] <= 5) || (C[i][1] + C[i][2] <= 5)) {
+			if ((C[i][0] + C[i][1] <= LOW_THRESH) || (C[i][1] + C[i][2] <= HIGH_THRESH)) {
 				tc.passed_iid_permutation_tests = false;
 				break;
 			}

--- a/cpp/iid/permutation_tests.h
+++ b/cpp/iid/permutation_tests.h
@@ -8,6 +8,7 @@
 #include <unistd.h>
 #include <vector>
 #include <iomanip>
+#include <atomic>
 
 // The tests used
 const unsigned int num_tests = 19;
@@ -583,6 +584,9 @@ bool permutation_tests(const data_t *dp, const double rawmean, const double medi
 
 	// Progress
 	size_t completed = 0;
+	int total_perms = PERMS;
+	std::atomic<int> next_percent{10};
+	int completed_test_index = 0;
 
 	// Counters for the pass/fail of each statistic
 	int C[num_tests][3];
@@ -650,56 +654,40 @@ bool permutation_tests(const data_t *dp, const double rawmean, const double medi
 		//Cause the RNG to jump omp_get_thread_num() * 2^128 calls
 		xoshiro_jump(omp_get_thread_num(), xoshiro256starstarSeed);
 
+		// Remove verbose per-iteration progress logic
+
 		#pragma omp for
 		for(int i = 0; i < PERMS; ++i) {
+			FYshuffle(data, rawdata, dp->len, xoshiro256starstarSeed);
+			run_tests(dp, data, rawdata, rawmean, median, tp, test_status);
+
+			#pragma omp critical(resultUpdate)
 			{
-				char statusMessage[1024];
-				size_t statusMessageLength = 0;
-
-				FYshuffle(data, rawdata, dp->len, xoshiro256starstarSeed);
-				run_tests(dp, data, rawdata, rawmean, median, tp, test_status);
-
-				#pragma omp critical(resultUpdate)
-				{
-					for(unsigned int j = 0; j < num_tests; ++j){
-						if(test_status[j]) {
-							if (tp[j] < t[j]) {
-								C[j][0]++;
-							} else if (tp[j] == t[j]) {
-								C[j][1]++;
-							} else {
-								C[j][2]++;
-							}
+				for(unsigned int j = 0; j < num_tests; ++j){
+					if(test_status[j]) {
+						if (tp[j] < t[j]) {
+							C[j][0]++;
+						} else if (tp[j] == t[j]) {
+							C[j][1]++;
+						} else {
+							C[j][2]++;
 						}
 					}
-					completed++;
 				}
-
-				if(verbose == 2) {
-					int res;
-					if(istty) {
-						statusMessage[0] = '\r';
-						statusMessage[1] = '\0';
-						statusMessageLength = 1;
-					} else {
-						statusMessage[0] = '\0';
-						statusMessageLength = 0;
-					}
-
-					res = snprintf(statusMessage+statusMessageLength, sizeof(statusMessage)-statusMessageLength,
-								   "\n %6.02f%% of Permutation test rounds", (100.0*((float)completed)/((float)PERMS)));
-					assert(res>0);
-					statusMessageLength += res;
-					assert(statusMessageLength < sizeof(statusMessage));
-
-					#pragma omp critical(verboseOutput)
-					{
-						fputs(statusMessage, stdout);
-						fflush(stdout);
-					}
-				}
+				completed++;
 			}
+			// Remove all per-iteration prints
 		}
+
+		// Only one thread prints the progress bar at the end of the test
+		#pragma omp master
+		{
+			std::cout << "[";
+			for(int i = 0; i < 10; ++i) std::cout << "#";
+			std::cout << "] All permutation rounds complete for test " << (completed_test_index+1) << " of " << num_tests << std::endl;
+			completed_test_index++;
+		}
+
 		delete[](data);
 		delete[](rawdata);
 	} //end parallel

--- a/cpp/iid/permutation_tests.h
+++ b/cpp/iid/permutation_tests.h
@@ -1,7 +1,8 @@
+#include <fstream>
 #include <memory>
 #include <chrono>
-#include <fstream> // For ofstream
 #include <cstdio>  // For fileno
+#include <fstream>
 #pragma once
 
 #include <stdlib.h>
@@ -606,10 +607,12 @@ bool permutation_tests(const data_t *dp, const double rawmean, const double medi
 	// Status stream for progress output (tty or redirected)
 	std::ostream* status_stream = &std::cout;
 	std::unique_ptr<std::ofstream> tty_out;
-	if (istty) {
-	    tty_out = std::unique_ptr<std::ofstream>(new std::ofstream("/dev/tty"));
+	if (!istty) {
+	    // Try opening /dev/tty directly for terminal output even if stdout is redirected
+	    tty_out.reset(new std::ofstream("/dev/tty"));
 	    if (tty_out->is_open()) {
 	        status_stream = tty_out.get();
+	        istty = true; // enable status updates
 	    }
 	}
 
@@ -643,8 +646,9 @@ bool permutation_tests(const data_t *dp, const double rawmean, const double medi
 	}
 	
 	if(verbose == 2) cout << "Beginning permutation tests... these may take some time" << endl;
-	if (istty) {
-	    *status_stream << "[----------] 0/" << PERMS << " - 0.00% of total permutation complete...\nElapsed: 0s\nETA (HH:MM:SS): 00:00:00" << std::flush;
+	if(verbose >= 1) std::cout << std::endl;
+	if (istty && verbose >= 1) {
+	    *status_stream << "\n[----------] 0/" << PERMS << " - 0.00% of total permutation complete...\nElapsed: 0s\nETA (HH:MM:SS): 00:00:00" << std::flush;
 	}
 
 	// Progress tracking for all permutations
@@ -721,6 +725,7 @@ bool permutation_tests(const data_t *dp, const double rawmean, const double medi
 			                    *status_stream << "Elapsed: " << elapsed << "s" << std::endl;
 			                    *status_stream << "ETA (HH:MM:SS): " << std::setfill('0') << std::setw(2) << eta_h << ":"
 			                              << std::setw(2) << eta_m << ":" << std::setw(2) << eta_s << std::flush;
+			                    std::cout << std::flush;  // Ensure no buffer bleed into terminal rendering
 			                }
 			            }
 			        }
@@ -744,8 +749,8 @@ bool permutation_tests(const data_t *dp, const double rawmean, const double medi
 		delete[](rawdata);
 	} //end parallel
 
-	if (istty) {
-		*status_stream << "\r\033[K[##########] " << PERMS << "/" << PERMS
+	if (istty && verbose >= 1) {
+		*status_stream << "\n[##########] " << PERMS << "/" << PERMS
 				  << " - 100.00% of total permutation complete. ✅ Done.\n";
 	}
 	if(verbose > 1) print_results(C, verbose);

--- a/cpp/iid/permutation_tests.h
+++ b/cpp/iid/permutation_tests.h
@@ -1,3 +1,4 @@
+#include <chrono>
 #pragma once
 
 #include <stdlib.h>
@@ -579,11 +580,11 @@ void populateTestCase(IidTestCase &tc, int C[][3]){
 }
 
 bool permutation_tests(const data_t *dp, const double rawmean, const double median, const int verbose, IidTestCase &tc){
+	auto start_time = std::chrono::steady_clock::now();
 	uint64_t xoshiro256starstarMainSeed[4];
 	bool istty;
 
 	// Progress
-	size_t completed = 0;
 	int total_perms = PERMS;
 	std::atomic<int> next_percent{10};
 	int completed_test_index = 0;
@@ -629,6 +630,12 @@ bool permutation_tests(const data_t *dp, const double rawmean, const double medi
 	}
 	
 	if(verbose == 2) cout << "Beginning permutation tests... these may take some time" << endl;
+	if (istty) {
+	    std::cout << "[----------] 0/" << PERMS << " - 0.00% of total permutation complete...\nElapsed: 0s\nETA (HH:MM:SS): 00:00:00" << std::flush;
+	}
+
+	// Progress tracking for all permutations
+	std::atomic<size_t> completed{0};
 
 	#pragma omp parallel
 	{
@@ -654,8 +661,6 @@ bool permutation_tests(const data_t *dp, const double rawmean, const double medi
 		//Cause the RNG to jump omp_get_thread_num() * 2^128 calls
 		xoshiro_jump(omp_get_thread_num(), xoshiro256starstarSeed);
 
-		// Remove verbose per-iteration progress logic
-
 		#pragma omp for
 		for(int i = 0; i < PERMS; ++i) {
 			FYshuffle(data, rawdata, dp->len, xoshiro256starstarSeed);
@@ -674,24 +679,48 @@ bool permutation_tests(const data_t *dp, const double rawmean, const double medi
 						}
 					}
 				}
-				completed++;
+				int p = ++completed;
+				if (istty) {
+					static thread_local int last_percent = -1;
+					int current_percent = (p * 10000) / PERMS; // percent in hundredths
+					if (current_percent > last_percent) {
+						last_percent = current_percent;
+						#pragma omp critical(printProgress)
+						{
+							float percent_display = (100.0f * p) / PERMS;
+							auto now = std::chrono::steady_clock::now();
+							auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(now - start_time).count();
+							double eta_seconds = (p > 0) ? (elapsed * (PERMS - p)) / double(p) : 0;
+							int eta_h = int(eta_seconds) / 3600;
+							int eta_m = (int(eta_seconds) % 3600) / 60;
+							int eta_s = int(eta_seconds) % 60;
+							// Clear previous lines (progress bar, elapsed, ETA)
+							std::cout << "\r\033[K"; // Clear progress bar line
+							std::cout << "\033[F\033[K"; // Clear elapsed line
+							std::cout << "\033[F\033[K"; // Clear ETA line
+							std::cout << "[";
+							int completed_blocks = p * 10 / PERMS;
+							for (int b = 0; b < 10; ++b)
+								std::cout << (b < completed_blocks ? '#' : '-');
+							std::cout << "] " << p << "/" << PERMS << " - " << std::fixed << std::setprecision(2)
+									  << percent_display << "% of total permutation complete..." << std::endl;
+							std::cout << "Elapsed: " << elapsed << "s" << std::endl;
+							std::cout << "ETA (HH:MM:SS): " << std::setfill('0') << std::setw(2) << eta_h << ":"
+									  << std::setw(2) << eta_m << ":" << std::setw(2) << eta_s << std::flush;
+						}
+					}
+				}
 			}
-			// Remove all per-iteration prints
-		}
-
-		// Only one thread prints the progress bar at the end of the test
-		#pragma omp master
-		{
-			std::cout << "[";
-			for(int i = 0; i < 10; ++i) std::cout << "#";
-			std::cout << "] All permutation rounds complete for test " << (completed_test_index+1) << " of " << num_tests << std::endl;
-			completed_test_index++;
 		}
 
 		delete[](data);
 		delete[](rawdata);
 	} //end parallel
 
+	if (istty) {
+		std::cout << "\r\033[K[##########] " << PERMS << "/" << PERMS
+				  << " - 100.00% of total permutation complete. ✅ Done.\n";
+	}
 	if(verbose > 1) print_results(C, verbose);
 
     populateTestCase(tc, C);

--- a/cpp/iid/permutation_tests.h
+++ b/cpp/iid/permutation_tests.h
@@ -1,4 +1,7 @@
+#include <memory>
 #include <chrono>
+#include <fstream> // For ofstream
+#include <cstdio>  // For fileno
 #pragma once
 
 #include <stdlib.h>
@@ -476,13 +479,13 @@ void print_results(int C[][3], const int verbose){
 	cout << "----------------------------------------------------" << endl;
 	for(unsigned int i = 0; i < num_tests; ++i){
 		if((C[i][0] + C[i][1] <= 5) || C[i][1] + C[i][2] <= 5){
-			cout << setw(24) << test_names[i] << "*";
+			cout << std::left << std::setw(25) << (test_names[i] + "*") << std::right;
 		}else{
-			cout << setw(25) << test_names[i];
+			cout << std::left << std::setw(25) << test_names[i] << std::right;
 		}
-		cout << setw(8) << C[i][0];
-		cout << setw(8) << C[i][1];
-		cout << setw(8) << C[i][2] << endl;
+		cout << "  " << std::setw(5) << C[i][0]
+		     << "  " << std::setw(5) << C[i][1]
+		     << "  " << std::setw(5) << C[i][2] << endl;
 	}
 	cout << "(* denotes failed test)" << endl;
 	cout << endl;
@@ -582,7 +585,6 @@ void populateTestCase(IidTestCase &tc, int C[][3]){
 bool permutation_tests(const data_t *dp, const double rawmean, const double median, const int verbose, IidTestCase &tc){
 	auto start_time = std::chrono::steady_clock::now();
 	uint64_t xoshiro256starstarMainSeed[4];
-	bool istty;
 
 	// Progress
 	int total_perms = PERMS;
@@ -598,7 +600,18 @@ bool permutation_tests(const data_t *dp, const double rawmean, const double medi
 	// To store p-values
 	std::vector<double> p_values(num_tests, 0.0);
 
-	istty = (isatty(fileno(stderr)) == 1);
+	bool istty;
+	istty = (isatty(fileno(stdout)) == 1);
+
+	// Status stream for progress output (tty or redirected)
+	std::ostream* status_stream = &std::cout;
+	std::unique_ptr<std::ofstream> tty_out;
+	if (istty) {
+	    tty_out = std::unique_ptr<std::ofstream>(new std::ofstream("/dev/tty"));
+	    if (tty_out->is_open()) {
+	        status_stream = tty_out.get();
+	    }
+	}
 
 	// Build map of results
 	for(unsigned int i = 0; i < num_tests; ++i){
@@ -631,7 +644,7 @@ bool permutation_tests(const data_t *dp, const double rawmean, const double medi
 	
 	if(verbose == 2) cout << "Beginning permutation tests... these may take some time" << endl;
 	if (istty) {
-	    std::cout << "[----------] 0/" << PERMS << " - 0.00% of total permutation complete...\nElapsed: 0s\nETA (HH:MM:SS): 00:00:00" << std::flush;
+	    *status_stream << "[----------] 0/" << PERMS << " - 0.00% of total permutation complete...\nElapsed: 0s\nETA (HH:MM:SS): 00:00:00" << std::flush;
 	}
 
 	// Progress tracking for all permutations
@@ -668,48 +681,62 @@ bool permutation_tests(const data_t *dp, const double rawmean, const double medi
 
 			#pragma omp critical(resultUpdate)
 			{
-				for(unsigned int j = 0; j < num_tests; ++j){
-					if(test_status[j]) {
-						if (tp[j] < t[j]) {
-							C[j][0]++;
-						} else if (tp[j] == t[j]) {
-							C[j][1]++;
-						} else {
-							C[j][2]++;
-						}
-					}
-				}
-				int p = ++completed;
-				if (istty) {
-					static thread_local int last_percent = -1;
-					int current_percent = (p * 10000) / PERMS; // percent in hundredths
-					if (current_percent > last_percent) {
-						last_percent = current_percent;
-						#pragma omp critical(printProgress)
-						{
-							float percent_display = (100.0f * p) / PERMS;
-							auto now = std::chrono::steady_clock::now();
-							auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(now - start_time).count();
-							double eta_seconds = (p > 0) ? (elapsed * (PERMS - p)) / double(p) : 0;
-							int eta_h = int(eta_seconds) / 3600;
-							int eta_m = (int(eta_seconds) % 3600) / 60;
-							int eta_s = int(eta_seconds) % 60;
-							// Clear previous lines (progress bar, elapsed, ETA)
-							std::cout << "\r\033[K"; // Clear progress bar line
-							std::cout << "\033[F\033[K"; // Clear elapsed line
-							std::cout << "\033[F\033[K"; // Clear ETA line
-							std::cout << "[";
-							int completed_blocks = p * 10 / PERMS;
-							for (int b = 0; b < 10; ++b)
-								std::cout << (b < completed_blocks ? '#' : '-');
-							std::cout << "] " << p << "/" << PERMS << " - " << std::fixed << std::setprecision(2)
-									  << percent_display << "% of total permutation complete..." << std::endl;
-							std::cout << "Elapsed: " << elapsed << "s" << std::endl;
-							std::cout << "ETA (HH:MM:SS): " << std::setfill('0') << std::setw(2) << eta_h << ":"
-									  << std::setw(2) << eta_m << ":" << std::setw(2) << eta_s << std::flush;
-						}
-					}
-				}
+			    for (unsigned int j = 0; j < num_tests; ++j) {
+			        if(test_status[j]) {
+			            if (tp[j] < t[j]) {
+			                C[j][0]++;
+			            } else if (tp[j] == t[j]) {
+			                C[j][1]++;
+			            } else {
+			                C[j][2]++;
+			            }
+			        }
+			    }
+			    int p = ++completed;
+			    if (verbose >= 1 && istty) {
+			        static thread_local int last_percent = -1;
+			        int current_percent = (p * 10000) / PERMS; // percent in hundredths
+			        if (current_percent > last_percent) {
+			            last_percent = current_percent;
+			            #pragma omp critical(printProgress)
+			            {
+			                float percent_display = (100.0f * p) / PERMS;
+			                auto now = std::chrono::steady_clock::now();
+			                auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(now - start_time).count();
+			                double eta_seconds = (p > 0) ? (elapsed * (PERMS - p)) / double(p) : 0;
+			                int eta_h = int(eta_seconds) / 3600;
+			                int eta_m = (int(eta_seconds) % 3600) / 60;
+			                int eta_s = int(eta_seconds) % 60;
+			                // Use ANSI escape codes to clear and update the dynamic progress display
+			                if (istty) {
+			                    *status_stream << "\r\033[K";
+			                    *status_stream << "\033[F\033[K";
+			                    *status_stream << "\033[F\033[K";
+			                    *status_stream << "[";
+			                    int completed_blocks = p * 10 / PERMS;
+			                    for (int b = 0; b < 10; ++b)
+			                        *status_stream << (b < completed_blocks ? '#' : '-');
+			                    *status_stream << "] " << p << "/" << PERMS << " - " << std::fixed << std::setprecision(2)
+			                              << percent_display << "% of total permutation complete..." << std::endl;
+			                    *status_stream << "Elapsed: " << elapsed << "s" << std::endl;
+			                    *status_stream << "ETA (HH:MM:SS): " << std::setfill('0') << std::setw(2) << eta_h << ":"
+			                              << std::setw(2) << eta_m << ":" << std::setw(2) << eta_s << std::flush;
+			                }
+			            }
+			        }
+			    } else {
+			        // For non-tty (e.g. redirected to a file), only print a single final progress message.
+			        if (p == PERMS) {
+			            float percent_display = (100.0f * p) / PERMS;
+			            auto now = std::chrono::steady_clock::now();
+			            auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(now - start_time).count();
+			            *status_stream << "[##########] " << p << "/" << PERMS << " - " 
+			                      << std::fixed << std::setprecision(2) << percent_display 
+			                      << "% of total permutation complete. ✅ Done." << std::endl;
+			            *status_stream << "Elapsed: " << elapsed << "s" << std::endl;
+			            *status_stream << "ETA (HH:MM:SS): 00:00:00" << std::endl;
+			        }
+			    }
 			}
 		}
 
@@ -718,7 +745,7 @@ bool permutation_tests(const data_t *dp, const double rawmean, const double medi
 	} //end parallel
 
 	if (istty) {
-		std::cout << "\r\033[K[##########] " << PERMS << "/" << PERMS
+		*status_stream << "\r\033[K[##########] " << PERMS << "/" << PERMS
 				  << " - 100.00% of total permutation complete. ✅ Done.\n";
 	}
 	if(verbose > 1) print_results(C, verbose);
@@ -738,13 +765,16 @@ bool permutation_tests(const data_t *dp, const double rawmean, const double medi
     tc.p_values.clear();
     for (unsigned int i = 0; i < num_tests; ++i) {
 		 int total = PERMS;
-		 double p = (C[i][2] + C[i][1]) / total;
+		 double c0 = static_cast<double>(C[i][0]);
+		 double c1 = static_cast<double>(C[i][1]);
+		 double c2 = static_cast<double>(C[i][2]);
+		 double p = (0.5 * (c0 + c2) + c1) / total;
 		 p_values[i] = p;
 		 tc.p_values.push_back(p);
 		 if (verbose >= 1)
 		 {
-			 std::cout << "    " << std::setw(23) << test_names[i]
-						  << "  P-value: " << std::fixed << std::setprecision(6) << p << std::endl;
+			 std::cout << "    " << std::left << std::setw(25) << test_names[i]
+			           << "P-value: " << std::fixed << std::setprecision(6) << p << std::endl;
 		 }
     }
     return true;

--- a/cpp/iid/permutation_tests.h
+++ b/cpp/iid/permutation_tests.h
@@ -726,7 +726,7 @@ bool permutation_tests(const data_t *dp, const double rawmean, const double medi
     populateTestCase(tc, C);
 	 tc.passed_iid_permutation_tests = true;
 		for (unsigned int i = 0; i < num_tests; ++i) {
-			if ((C[i][0] + C[i][1] <= LOW_THRESH) || (C[i][1] + C[i][2] >= HIGH_THRESH)) {
+			if ((C[i][0] + C[i][1] <= LOW_THRESH) || (C[i][0] + C[i][2] >= HIGH_THRESH)) {
 				tc.passed_iid_permutation_tests = false;
 				break;
 			}
@@ -737,14 +737,15 @@ bool permutation_tests(const data_t *dp, const double rawmean, const double medi
     }
     tc.p_values.clear();
     for (unsigned int i = 0; i < num_tests; ++i) {
-        int total = C[i][0] + C[i][1] + C[i][2];
-        double p = (C[i][2] + 0.5 * C[i][1]) / total;
-        p_values[i] = p;
-        tc.p_values.push_back(p);
-        if (verbose >= 1) {
-            std::cout << "    " << std::setw(23) << test_names[i]
-                      << "  P-value: " << std::fixed << std::setprecision(6) << p << std::endl;
-        }
+		 int total = PERMS;
+		 double p = (C[i][2] + C[i][1]) / total;
+		 p_values[i] = p;
+		 tc.p_values.push_back(p);
+		 if (verbose >= 1)
+		 {
+			 std::cout << "    " << std::setw(23) << test_names[i]
+						  << "  P-value: " << std::fixed << std::setprecision(6) << p << std::endl;
+		 }
     }
     return true;
 }

--- a/cpp/iid/permutation_tests.h
+++ b/cpp/iid/permutation_tests.h
@@ -697,7 +697,7 @@ bool permutation_tests(const data_t *dp, const double rawmean, const double medi
     populateTestCase(tc, C);
 	 tc.passed_iid_permutation_tests = true;
 		for (unsigned int i = 0; i < num_tests; ++i) {
-			if ((C[i][0] + C[i][1] <= LOW_THRESH) || (C[i][1] + C[i][2] <= HIGH_THRESH)) {
+			if ((C[i][0] + C[i][1] <= LOW_THRESH) || (C[i][1] + C[i][2] >= HIGH_THRESH)) {
 				tc.passed_iid_permutation_tests = false;
 				break;
 			}


### PR DESCRIPTION
## Update the IID permutation test:
- [x] To not quit _early_ before finishing all permutations for all tests. <br>

New Example Output for 10,000 permutations:
```
                statistic  C[i][0]  C[i][1]  C[i][2]
----------------------------------------------------
excursion                   8083      0   1917
numDirectionalRuns          3818      8   6174
lenDirectionalRuns            64   5938   3998
numIncreasesDecreases        741      2   9257
numRunsMedian                428      3   9569
lenRunsMedian               1485   2354   6161
avgCollision                2888      2   7110
maxCollision                7561    607   1832
periodicity(1)              6954     44   3002
periodicity(2)              1752     44   8204
periodicity(8)              4966     60   4974
periodicity(16)             3001     63   6936
periodicity(32)              110      6   9884
covariance(1)               8801      0   1199
covariance(2)               3075      0   6925
covariance(8)               3005      0   6995
covariance(16)              5663      0   4337
covariance(32)              9497      0    503
compression                 5423     15   4562
(* denotes failed test)
```

- [x] Fix the parameters for pass/fail to be _dynamic_ based on the number of permutations <br> 

For Example:<br>
 Passing criteria if the total number of `permutations = 10000 `
 $50 >= C[0]$, `&&`
 $9950 >= C[2]$ <br><br>
 
- [x]  Add calculation for the p-values for each of the permutation subtests, using the following formula: <br>

$p = \frac{0.5 \cdot (C[0] + C[2]) + C[1]}{\text{total permutations}}$ <br><br>

Example Output:
```
=== Permutation Test P-values ===
    excursion                P-value: 0.500000
    numDirectionalRuns       P-value: 0.500400
    lenDirectionalRuns       P-value: 0.796900
    numIncreasesDecreases    P-value: 0.500100
    numRunsMedian            P-value: 0.500150
    lenRunsMedian            P-value: 0.617700
    avgCollision             P-value: 0.500100
    maxCollision             P-value: 0.530350
    periodicity(1)           P-value: 0.502200
    periodicity(2)           P-value: 0.502200
    periodicity(8)           P-value: 0.503000
    periodicity(16)          P-value: 0.503150
    periodicity(32)          P-value: 0.500300
    covariance(1)            P-value: 0.500000
    covariance(2)            P-value: 0.500000
    covariance(8)            P-value: 0.500000
    covariance(16)           P-value: 0.500000
    covariance(32)           P-value: 0.500000
    compression              P-value: 0.500750
```

- [x] Fixing the status updates to only print out in the terminal _dynamically_ (not printing at all in any log files to not cloud results), and adding an ETA and Elapsed time measure as well: <br>

Example Output:
```
[#---------] 1243/10000 - 12.43% of total permutation complete...
Elapsed: 133s
ETA (HH:MM:SS): 00:15:36
```