### PR TITLE
Fix makefile - avoid unnecessary rebuilds and other confusion

### DIFF
--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -42,6 +42,7 @@ ea_transpose: transpose_main.cpp
 	$(CXX) $(CXXFLAGS) $(INC) transpose_main.cpp -o ea_transpose $(LIB) $(SHARED_LIB)
 
 
+.PHONY: all clean
 .PHONY: iid non_iid restart conditioning transpose
 
 iid: ea_iid

--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -20,27 +20,36 @@ INC =
 # Main operations
 ######
 
+	# note tha these names are convenience names - not the names of actual files
 all:    iid non_iid restart conditioning transpose
 
 clean:
 	rm -f ea_iid ea_non_iid ea_restart ea_conditioning ea_transpose selftest/*.res
 
-iid: iid_main.o
-iid_main.o: iid_main.cpp
+ea_iid: iid_main.cpp
 	$(CXX) $(CXXFLAGS) $(INC) iid_main.cpp -o ea_iid $(LIB) $(SHARED_LIB)
 	
-non_iid: non_iid_main.o	
-non_iid_main.o: non_iid_main.cpp
+ea_non_iid: non_iid_main.cpp
 	$(CXX) $(CXXFLAGS) $(INC) non_iid_main.cpp -o ea_non_iid $(LIB) $(SHARED_LIB)
 
-restart: restart_main.o
-restart_main.o: restart_main.cpp
+ea_restart: restart_main.cpp
 	$(CXX) $(CXXFLAGS) $(INC) restart_main.cpp -o ea_restart $(LIB) $(SHARED_LIB)
 
-conditioning: conditioning_main.o
-conditioning_main.o: conditioning_main.cpp
+ea_conditioning: conditioning_main.cpp
 	$(CXX) $(CXXFLAGS) $(INC) conditioning_main.cpp -o ea_conditioning $(LIB) $(COND_LIB) $(SHARED_LIB)
 
-transpose: transpose_main.o
-transpose_main.o: transpose_main.cpp
+ea_transpose: transpose_main.cpp
 	$(CXX) $(CXXFLAGS) $(INC) transpose_main.cpp -o ea_transpose $(LIB) $(SHARED_LIB)
+
+
+.PHONY: iid non_iid restart conditioning transpose
+
+iid: ea_iid
+
+non_iid: ea_non_iid
+
+restart: ea_restart
+
+conditioning: ea_conditioning
+
+transpose: ea_transpose


### PR DESCRIPTION
The original Makefile used convenience names as targets (e.g. iid) which were not the names of outputs actually generated (`iid` generated an executable `ea_iid`). This meant that make would always rebuild these targets as the build recipe would never create the target.
 
This would also have been vulnerable to being broken if a file was present whose name was that of a convenience target (and a few had directories with their names), but this didn't happen because the dependencies used intermediate object files that were never actually created, so building `iid` would see that it existed (as a directory) and depended on non-existent `iid_main.o` so attempt to build that. Since the recipe for `iid_main.o` instead built `ea_iid` this had the effect of always building `ea_iid`. Then the recipe for building `iid` from `ea_iid.o` would run, but did nothing so was not visible.
 
This change expresses the actual dependencies and makes the convenience names `.PHONY` so make knows that they do not refer to files and any such files are to have no effect.