### PR TITLE
Reduce the impact of floating point rounding in the `calc_proportions()` function

### DIFF
--- a/cpp/shared/utils.h
+++ b/cpp/shared/utils.h
@@ -749,8 +749,15 @@ void map_init(map<pair<uint8_t, uint8_t>, int> &m) {
 
 // Calculates proportions of each value as an index
 void calc_proportions(const uint8_t data[], vector<double> &p, const int sample_size) {
+	unsigned int symbolNumber = p.size();
+	
 	for (int i = 0; i < sample_size; i++) {
-		p[data[i]] += (1.0 / sample_size);
+		p[data[i]] ++;
+	}
+
+	//p now contains symbol counts. Normalize to the per-symbol probability
+	for (int i = 0; i < symbolNumber; i++) {
+		p[i] /= (double)sample_size;
 	}
 }
 


### PR DESCRIPTION
The prior code iteratively adds values of the form 1/L (where L is the number of symbols in the raw dataset) as many as L times, which will tend to accumulate floating point error in instances where the size of the accumulated sum becomes large as compared to 1/L.

This alternate approach sums the integer number of values each symbol is seen. A 64-bit double can accurately represent all integers up to approximately 2^53 (due to the 52-bit mantissa), so we don't run into rounding issues until we process datasets larger than 4 petabytes.

To keep return values consistent with the prior code, there is then a final step where each count is divided by L.

Resolves usnistgov/SP800-90B_EntropyAssessment#246