### PR TITLE
Fix IID JSON hAssessed at default verbosity

### DIFF
--- a/cpp/iid_main.cpp
+++ b/cpp/iid_main.cpp
@@ -284,6 +284,13 @@ int main(int argc, char* argv[]) {
     tc.h_bitstring = H_bitstring;
 
     double h_assessed = data.word_size;
+    if ((data.alph_size > 2) || !initial_entropy) {
+        h_assessed = min(h_assessed, H_bitstring * data.word_size);
+    }
+    if (initial_entropy) {
+        h_assessed = min(h_assessed, H_original);
+    }
+
     if ((verbose == 1) || (verbose == 2)) {
         if (initial_entropy) {
             printf("H_original: %f\n", H_original);
@@ -295,16 +302,12 @@ int main(int argc, char* argv[]) {
             printf("h': %f\n", H_bitstring);
         }
     } else if (verbose > 2) {
-        h_assessed = data.word_size;
-
         if ((data.alph_size > 2) || !initial_entropy) {
-            h_assessed = min(h_assessed, H_bitstring * data.word_size);
             printf("H_bitstring = %.17g\n", H_bitstring);
             printf("H_bitstring Per Symbol = %.17g\n", H_bitstring * data.word_size);
         }
 
         if (initial_entropy) {
-            h_assessed = min(h_assessed, H_original);
             printf("H_original = %.17g\n", H_original);
         }
 


### PR DESCRIPTION
The IID path computed `hAssessed` inside the `verbose > 2` diagnostic block. At default JSON verbosity, `h_assessed` stayed at `data.word_size`, so multi-bit inputs could report the full word size even when `H_original` or `bits_per_symbol * H_bitstring` gave a lower assessment. The fix moves the `min()` reductions before the verbosity branches and keeps only the `printf` calls gated on verbosity.

Reproduced on the bundled `biased-random-bytes.bin`. Unpatched default JSON reports:

```text
hAssessed = 8.0
```

The actual assessment is:

```text
hAssessed = 0.31965065183818203
```

After the fix, default JSON and `-vvv` JSON agree:

```text
hAssessed = 0.31965065183818203
hBitstring = 0.15182732507652344
hOriginal = 0.31965065183818203
```